### PR TITLE
Bug fixes and afc2 access in cython bindings

### DIFF
--- a/cython/lockdown.pxi
+++ b/cython/lockdown.pxi
@@ -90,7 +90,7 @@ cdef class LockdownPairRecord:
             cdef bytes result = self._c_record.root_certificate
             return result
 
-cdef class LockdownServiceDescriptor:
+cdef class LockdownServiceDescriptor(Base):
     #def __cinit__(self, uint16_t port, uint8_t ssl_enabled, *args, **kwargs):
     def __dealloc__(self):
         cdef lockdownd_error_t err


### PR DESCRIPTION
This commit fixes several compile errors I encountered and adds the ability
to use "com.apple.afc2" for jailbroken devices using the cython bindings.
In afc.pxi:
- Add Afc2Client subclass for "com.apple.afc2" access.
- Add read() method to AfcFile
- Initialize some pointers to NULL at time of declaration

In lockdown.pxi:
- Make LockdownServiceDescriptor inherit from Base, since it calls
  self.handle_error
- Explicitly cast ssl_enabled when calling lockdownd_start_session
