### PR TITLE
Enable unback of encrypted backups.

### DIFF
--- a/src/mobilebackup2.c
+++ b/src/mobilebackup2.c
@@ -438,6 +438,12 @@ mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, 
 	if (options) {
 		plist_dict_insert_item(dict, "Options", plist_copy(options));
 	}
+	if (!strcmp(request, "Unback") && options) {
+		plist_t password = plist_dict_get_item(options, "Password");
+		if (password) {
+			plist_dict_insert_item(dict, "Password", plist_copy(password));
+		}
+	}
 	mobilebackup2_error_t err = mobilebackup2_send_message(client, request, dict);
 	plist_free(dict);
 

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -1810,7 +1810,15 @@ checkpoint:
 			break;
 			case CMD_UNBACK:
 			PRINT_VERBOSE(1, "Starting to unpack backup...\n");
-			err = mobilebackup2_send_request(mobilebackup2, "Unback", udid, source_udid, NULL);
+			if (backup_password != NULL) {
+				opts = plist_new_dict();
+				plist_dict_insert_item(opts, "Password", plist_new_string(backup_password));
+			}
+			PRINT_VERBOSE(1, "Backup password: %s\n", (backup_password == NULL ? "No":"Yes"));
+			err = mobilebackup2_send_request(mobilebackup2, "Unback", udid, source_udid, opts);
+			if (backup_password !=NULL) {
+				plist_free(opts);
+			}
 			if (err != MOBILEBACKUP2_E_SUCCESS) {
 				printf("Error requesting unback operation from device, error code %d\n", err);
 				cmd = CMD_LEAVE;


### PR DESCRIPTION
Adds the supplied password to the Unback request, which is sent in the main message, not in an options dictionary.
