### PR TITLE
Backward compatible interface for udid

### DIFF
--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -66,7 +66,10 @@ enum idevice_event_type {
 /** Provides information about the occured event. */
 typedef struct {
 	enum idevice_event_type event; /**< The event type. */
-	const char *udid; /**< The device unique id. */
+	union {
+		const char *udid; /**< The device unique id. */
+		const char *uuid;
+	};
 	int conn_type; /**< The connection type. Currently only 1 for usbmuxd. */
 } idevice_event_t;
 
@@ -100,6 +103,7 @@ idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
 /* misc */
 idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle);
 idevice_error_t idevice_get_udid(idevice_t device, char **udid);
+idevice_error_t idevice_get_uuid(idevice_t device, char **udid);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/lockdown.h
+++ b/include/libimobiledevice/lockdown.h
@@ -102,6 +102,7 @@ lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
 /* Helper */
 void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
 lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t control, char **udid);
+lockdownd_error_t lockdownd_get_device_uuid(lockdownd_client_t control, char **udid);
 lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name);
 lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count);
 lockdownd_error_t lockdownd_data_classes_free(char **classes);

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -480,6 +480,11 @@ idevice_error_t idevice_get_udid(idevice_t device, char **udid)
 	return IDEVICE_E_SUCCESS;
 }
 
+idevice_error_t idevice_get_uuid(idevice_t device, char **udid)
+{
+	return idevice_get_udid(device, udid);
+}
+
 #ifndef HAVE_OPENSSL
 /**
  * Internally used gnutls callback function for receiving encrypted data.

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -570,6 +570,11 @@ lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **ud
 	return ret;
 }
 
+lockdownd_error_t lockdownd_get_device_uuid(lockdownd_client_t client, char **udid)
+{
+	return lockdownd_get_device_udid(client, udid);
+}
+
 /**
  * Retrieves the public key of the device from lockdownd.
  *


### PR DESCRIPTION
To let depending applications have easier migration to udid interface
there needs to be backward compatible interface wrappers in place.

Signed-off-by: Pauli Nieminen suokkos@gmail.com
