### PR TITLE
Cython HouseArrestClient fixes

### DIFF
--- a/cython/afc.pxi
+++ b/cython/afc.pxi
@@ -171,8 +171,9 @@ cdef class AfcClient(BaseService):
     __service_name__ = "com.apple.afc"
     cdef afc_client_t _c_client
 
-    def __cinit__(self, iDevice device not None, LockdownServiceDescriptor descriptor, *args, **kwargs):
-        self.handle_error(afc_client_new(device._c_dev, descriptor._c_service_descriptor, &(self._c_client)))
+    def __cinit__(self, iDevice device = None, LockdownServiceDescriptor descriptor = None, *args, **kwargs):
+        if (device is not None and descriptor is not None):
+            self.handle_error(afc_client_new(device._c_dev, descriptor._c_service_descriptor, &(self._c_client)))
     
     def __dealloc__(self):
         cdef afc_error_t err

--- a/cython/house_arrest.pxi
+++ b/cython/house_arrest.pxi
@@ -48,10 +48,10 @@ cdef class HouseArrestClient(PropertyListService):
     cdef inline BaseError _error(self, int16_t ret):
         return HouseArrestError(ret)
 
-    cdef send_request(self, plist.Node message):
+    cpdef send_request(self, plist.Node message):
         self.handle_error(house_arrest_send_request(self._c_client, message._c_node))
 
-    cdef send_command(self, bytes command, bytes appid):
+    cpdef send_command(self, bytes command, bytes appid):
         self.handle_error(house_arrest_send_command(self._c_client, command, appid))
 
     cpdef plist.Node get_result(self):


### PR DESCRIPTION
Changes to make cython HouseArrestClient functional. Allow HouseArrestClient to initialize the AfcClient without running afc's normal **cinit** body, and expose send_command and send_request methods to python.

References issue https://github.com/libimobiledevice/libimobiledevice/issues/53
