### PR TITLE
Added file_relay_request_sources_timeout() to allow specifying the timeout

### DIFF
--- a/include/libimobiledevice/file_relay.h
+++ b/include/libimobiledevice/file_relay.h
@@ -55,6 +55,7 @@ file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_
 file_relay_error_t file_relay_client_free(file_relay_client_t client);
 
 file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection);
+file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout);
 
 #ifdef __cplusplus
 }

--- a/src/file_relay.c
+++ b/src/file_relay.c
@@ -116,6 +116,7 @@ file_relay_error_t file_relay_client_free(file_relay_client_t client)
  *     data using idevice_connection_receive(). The connection will be closed
  *     automatically by the device, but use file_relay_client_free() to clean
  *     up properly.
+ * @param timeout Maximum time in milliseconds to wait for data.
  *
  * @note WARNING: Don't call this function without reading the data afterwards.
  *     A directory mobile_file_relay.XXXX used for creating the archive will
@@ -128,7 +129,7 @@ file_relay_error_t file_relay_client_free(file_relay_client_t client)
  *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
  *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
  */
-file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection)
+file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout)
 {
 	if (!client || !client->parent || !sources || !sources[0]) {
 		return FILE_RELAY_E_INVALID_ARG;
@@ -153,7 +154,7 @@ file_relay_error_t file_relay_request_sources(file_relay_client_t client, const 
 	plist_free(dict);
 
 	dict = NULL;
-	if (property_list_service_receive_plist_with_timeout(client->parent, &dict, 60000) != PROPERTY_LIST_SERVICE_E_SUCCESS) {
+	if (property_list_service_receive_plist_with_timeout(client->parent, &dict, timeout) != PROPERTY_LIST_SERVICE_E_SUCCESS) {
 		debug_info("ERROR: Could not receive answer from device!");
 		err = FILE_RELAY_E_MUX_ERROR;
 		goto leave;
@@ -215,4 +216,40 @@ leave:
 		plist_free(dict);
 	}
 	return err;
+}
+
+/**
+ * Request data for the given sources. Calls file_relay_request_sources_timeout() with
+ * a timeout of 60000 milliseconds (60 seconds).
+ *
+ * @param client The connected file_relay client.
+ * @param sources A NULL-terminated list of sources to retrieve.
+ *     Valid sources are:
+ *     - AppleSupport
+ *     - Network
+ *     - VPN
+ *     - WiFi
+ *     - UserDatabases
+ *     - CrashReporter
+ *     - tmp
+ *     - SystemConfiguration
+ * @param connection The connection that has to be used for receiving the
+ *     data using idevice_connection_receive(). The connection will be closed
+ *     automatically by the device, but use file_relay_client_free() to clean
+ *     up properly.
+ *
+ * @note WARNING: Don't call this function without reading the data afterwards.
+ *     A directory mobile_file_relay.XXXX used for creating the archive will
+ *     remain in the /tmp directory otherwise.
+ *
+ * @return FILE_RELAY_E_SUCCESS on succes, FILE_RELAY_E_INVALID_ARG when one or
+ *     more parameters are invalid, FILE_RELAY_E_MUX_ERROR if a communication
+ *     error occurs, FILE_RELAY_E_PLIST_ERROR when the received result is NULL
+ *     or is not a valid plist, FILE_RELAY_E_INVALID_SOURCE if one or more
+ *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
+ *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
+ */
+file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection)
+{
+	return file_relay_request_sources_timeout(client, sources, connection, 60000);
 }


### PR DESCRIPTION
I have encountered situations where the default timeout of 60 seconds while waiting for the initial request for sources is not sufficient. Resolved by adding a new function that accepts a custom timeout value.
