### PR TITLE
Fixed several memory leaks on deinit of OpenSSL

### DIFF
--- a/src/idevice.c
+++ b/src/idevice.c
@@ -83,14 +83,19 @@ static void internal_idevice_deinit(void)
 {
 #ifdef HAVE_OPENSSL
 	int i;
-	if (!mutex_buf)
-		return;
-	CRYPTO_set_id_callback(NULL);
-	CRYPTO_set_locking_callback(NULL);
-	for (i = 0; i < CRYPTO_num_locks(); i++)
-		mutex_destroy(&mutex_buf[i]);
-	free(mutex_buf);
-	mutex_buf = NULL;
+	if (mutex_buf) {
+		CRYPTO_set_id_callback(NULL);
+		CRYPTO_set_locking_callback(NULL);
+		for (i = 0; i < CRYPTO_num_locks(); i++)
+			mutex_destroy(&mutex_buf[i]);
+		free(mutex_buf);
+		mutex_buf = NULL;
+	}
+
+	/* Since there is no SSL_library_deinit... */
+	EVP_cleanup();
+	CRYPTO_cleanup_all_ex_data();
+	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
 #else
 	gnutls_global_deinit();
 #endif


### PR DESCRIPTION
You might also consider to include additional deinit procedures of OpenSSL to the internal_idevice_deinit(). In my case adding these lines was enough to eliminate most of a detected leaks
EVP_cleanup();
CRYPTO_cleanup_all_ex_data();
sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
but there are also some other procedures in OpenSSL doing deinit job, some of them are
CONF_modules_free();
ERR_remove_state(0);
ENGINE_cleanup();
CONF_modules_unload(1);
ERR_free_strings();
