### PR TITLE
Replace () with (void) in function prototypes

### DIFF
--- a/include/libimobiledevice/installation_proxy.h
+++ b/include/libimobiledevice/installation_proxy.h
@@ -279,7 +279,7 @@ instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t instproxy_client_options_new();
+plist_t instproxy_client_options_new(void);
 
 /**
  * Add one or more new key:value pairs to the given client_options.

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -95,7 +95,7 @@ idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occured.
  */
-idevice_error_t idevice_event_unsubscribe();
+idevice_error_t idevice_event_unsubscribe(void);
 
 /* discovery (synchronous) */
 

--- a/include/libimobiledevice/mobilesync.h
+++ b/include/libimobiledevice/mobilesync.h
@@ -321,7 +321,7 @@ void mobilesync_anchors_free(mobilesync_anchors_t anchors);
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t mobilesync_actions_new();
+plist_t mobilesync_actions_new(void);
 
 /**
  * Add one or more new key:value pairs to the given actions plist.


### PR DESCRIPTION
() and (void) are 2 different things in C, and can cause gcc warnings:

error: function declaration isn't a prototype [-Werror=strict-prototypes]
 idevice_error_t idevice_event_unsubscribe();

This commit replaces () with (void) in installed headers.
