### PR TITLE
cython: Add receive/receive_timeout methods for iDeviceConnection

### DIFF
--- a/cython/file_relay.pxi
+++ b/cython/file_relay.pxi
@@ -11,6 +11,7 @@ cdef extern from "libimobiledevice/file_relay.h":
         FILE_RELAY_E_MUX_ERROR = -3
         FILE_RELAY_E_INVALID_SOURCE = -4
         FILE_RELAY_E_STAGING_EMPTY = -5
+        FILE_RELAY_E_PERMISSION_DENIED = -6     # Permission denied on iOS8+. More detail: http://www.zdziarski.com/blog/?p=3820
         FILE_RELAY_E_UNKNOWN_ERROR = -256
 
     file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t descriptor, file_relay_client_t *client)
@@ -27,6 +28,7 @@ cdef class FileRelayError(BaseError):
             FILE_RELAY_E_MUX_ERROR: "MUX error",
             FILE_RELAY_E_INVALID_SOURCE: "Invalid source",
             FILE_RELAY_E_STAGING_EMPTY: "Staging empty",
+            FILE_RELAY_E_PERMISSION_DENIED: "Permission denied",
             FILE_RELAY_E_UNKNOWN_ERROR: "Unknown error"
         }
         BaseError.__init__(self, *args, **kwargs)

--- a/cython/imobiledevice.pxd
+++ b/cython/imobiledevice.pxd
@@ -38,6 +38,8 @@ cdef class iDeviceEvent:
 cdef class iDeviceConnection(Base):
     cdef idevice_connection_t _c_connection
 
+    cpdef bytes receive_timeout(self, uint32_t max_len, unsigned int timeout)
+    cpdef bytes receive(self, max_len)
     cpdef disconnect(self)
 
 cdef class iDevice(Base):

--- a/cython/imobiledevice.pyx
+++ b/cython/imobiledevice.pyx
@@ -128,6 +128,36 @@ cdef class iDeviceConnection(Base):
     def __init__(self, *args, **kwargs):
         raise TypeError("iDeviceConnection cannot be instantiated.  Please use iDevice.connect()")
 
+    cpdef bytes receive_timeout(self, uint32_t max_len, unsigned int timeout):
+        cdef:
+            uint32_t bytes_received
+            char* c_data = <char *>malloc(max_len)
+            bytes result
+
+        try:
+            self.handle_error(idevice_connection_receive_timeout(self._c_connection, c_data, max_len, &bytes_received, timeout))
+            result = c_data[:bytes_received]
+            return result
+        except BaseError, e:
+            raise
+        finally:
+            free(c_data)
+
+    cpdef bytes receive(self, max_len):
+        cdef:
+            uint32_t bytes_received
+            char* c_data = <char *>malloc(max_len)
+            bytes result
+
+        try:
+            self.handle_error(idevice_connection_receive(self._c_connection, c_data, max_len, &bytes_received))
+            result = c_data[:bytes_received]
+            return result
+        except BaseError, e:
+            raise
+        finally:
+            free(c_data)
+
     cpdef disconnect(self):
         cdef idevice_error_t err
         err = idevice_disconnect(self._c_connection)


### PR DESCRIPTION
Tested on iOS7.1.2/Python2.7:

~~~python
#!/usr/bin/env python

import sys
import plist
from imobiledevice import *

# modify from https://github.com/libimobiledevice/libimobiledevice/blob/master/dev/filerelaytest.c

def lockdown_get_service_client(service_class):
	ld = LockdownClient(iDevice())
	return ld.get_service_client(service_class)

def file_relay_get_UserDatabases():
	filerelay = lockdown_get_service_client(FileRelayClient)
	conn = filerelay.request_sources(["UserDatabases"])

	sys.stdout.write("Write dump.cpio.gz:\n")
	with open("dump.cpio.gz", "wb+") as dumpfile:
		while (1):
			try:
				#data = conn.receive_timeout(4096, 10)
				data = conn.receive(4096)
				dumpfile.write(data)

				sys.stdout.write(".")
			except Exception, e:
				if (e.code == -2):		# no more data
					break
				raise e

	print "Done"

def main():
	file_relay_get_UserDatabases()

if __name__ == '__main__':
	main()
~~~