### PR TITLE
Win32 support for idevicecrashreport

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -80,10 +80,8 @@ idevicedebug_CFLAGS = $(AM_CFLAGS)
 idevicedebug_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
 idevicedebug_LDADD = $(top_builddir)/src/libimobiledevice.la
 
-if !WIN32
 bin_PROGRAMS += idevicecrashreport
 idevicecrashreport_SOURCES = idevicecrashreport.c
 idevicecrashreport_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
 idevicecrashreport_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
 idevicecrashreport_LDADD = $(top_builddir)/src/libimobiledevice.la
-endif

--- a/tools/idevicecrashreport.c
+++ b/tools/idevicecrashreport.c
@@ -34,6 +34,7 @@
 #ifdef WIN32
 #define S_IFLNK S_IFREG
 #define S_IFSOCK S_IFREG
+#include "Shlwapi.h"
 #endif
 
 const char* target_directory = NULL;
@@ -43,7 +44,11 @@ static int keep_crash_reports = 0;
 static int file_exists(const char* path)
 {
 	struct stat tst;
+#ifdef WIN32
+	return (stat (path, &tst) == 0);
+#else
 	return (lstat(path, &tst) == 0);
+#endif
 }
 
 static int extract_raw_crash_report(const char* filename) {


### PR DESCRIPTION
This patch makes idevicecrashreport build on Windows using MinGW.