### PR TITLE
idevicedebug/enhancement: new option to kill app given a bundle ID

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -40,7 +40,8 @@
 
 enum cmd_mode {
 	CMD_NONE = 0,
-	CMD_RUN
+	CMD_RUN,
+	CMD_KILL
 };
 
 static int quit_flag = 0;
@@ -181,6 +182,7 @@ static void print_usage(int argc, char **argv)
 	printf("Interact with the debugserver service of a device.\n\n");
 	printf(" Where COMMAND is one of:\n");
 	printf("  run BUNDLEID [ARGS...]\trun app with BUNDLEID and optional ARGS on device.\n");
+	printf("  kill BUNDLEID\tkill app with BUNDLEID on device.\n");
 	printf("\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");
@@ -269,6 +271,20 @@ int main(int argc, char *argv[])
 			/*  read bundle identifier */
 			bundle_identifier = argv[i];
 			break;
+		} else if (!strcmp(argv[i], "kill")) {
+			cmd = CMD_KILL;
+
+			i++;
+			if (!argv[i]) {
+				/* make sure at least the bundle identifier was provided */
+				printf("Please supply the bundle identifier of the app to kill.\n");
+				print_usage(argc, argv);
+				res = 0;
+				goto cleanup;
+			}
+			/*  read bundle identifier */
+			bundle_identifier = argv[i];
+			break;
 		} else {
 			print_usage(argc, argv);
 			res = 0;
@@ -300,6 +316,8 @@ int main(int argc, char *argv[])
 	}
 
 	switch (cmd) {
+		case CMD_KILL:
+			quit_flag++;
 		case CMD_RUN:
 		default:
 			/* get the path to the app and it's working directory */

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -182,7 +182,7 @@ static void print_usage(int argc, char **argv)
 	printf("Interact with the debugserver service of a device.\n\n");
 	printf(" Where COMMAND is one of:\n");
 	printf("  run BUNDLEID [ARGS...]\trun app with BUNDLEID and optional ARGS on device.\n");
-	printf("  kill BUNDLEID\tkill app with BUNDLEID on device.\n");
+	printf("  kill BUNDLEID [ARGS...]\tkill app with BUNDLEID and optional ARGS on device.\n");
 	printf("\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");


### PR DESCRIPTION
Added a second option to idevicedebug to kill an app with specified bundle ID.

Usage: idevicedebug kill BUNDLEID [ARGS...]

If the app is running, the debugger attaches to the running process and kills it. It attaches using the exact same code flow as the run option.

If the app is not running, it starts the app briefly and then kills it, again using the exact same code path as run. I would prefer to detect if the process it not running and then simply exit with a message stating the the app was not killed because it was not running.

The following log shows that killing an app that is not running takes about 2 seconds on an iPhone 5c:

``` console
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: debugserver-300.2 for armv7.
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Connecting to com.apple.debugserver service...
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Got a connection, waiting for process information for launching or attaching.
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: About to launch process for bundle ID: com.domain.subdomain
12:35:58 iPhone-702 kernel[0] <Debug>: launchd[6656] Container: /private/var/mobile/Applications/9B294CAD-5935-48E1-8ADA-76C7417C8735 (sandbox)
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: In completion handler, got pid for bundle id, pid: 6656.
12:35:58 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Got a connection, launched process /Developer/usr/bin/debugserver.
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: debugserver's event read thread is exiting, killing the inferior process.
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Sending ptrace PT_KILL to terminate inferior process.
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: 1 +0.000000 sec [19ff/060b]: error: ::ptrace (request = PT_THUPDATE, pid = 0x1a00, tid = 0x2503, signal = 0) err = Resource busy (0x00000010)
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: 2 +0.002066 sec [19ff/060b]: error: ::task_info ( target_task = 0x1c0b, flavor = TASK_BASIC_INFO, task_info_out => 0x27dedec8, task_info_outCnt => 8 ) err = (os/kern) invalid argument (0x00000004)
12:36:00 iPhone-702 com.apple.launchd[1] (UIKitApplication:com.domain.subdomain[0xb0a8][6656]) <Notice>: (UIKitApplication:com.domain.subdomain[0xb0a8]) Exited: Killed: 9
12:36:00 iPhone-702 backboardd[28] <Warning>: Application 'UIKitApplication:com.domain.subdomain[0xb0a8]' exited abnormally with signal 9: Killed: 9
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Waited 20 ms for process to be reaped (state = Exited)
12:36:00 iPhone-702 com.apple.debugserver-300.2[6655] <Warning>: Exiting.
```

Please consider pulling-in this kill option to idevicedebug.
