### PR TITLE
 Visual C++ Compatibility: Configuration and Compatibility headers 

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -23,6 +23,11 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+
+#ifdef _MSC_VER
+#include "src/msc_config.h"
+#endif
+
 #include <stdarg.h>
 #define _GNU_SOURCE 1
 #define __USE_GNU 1

--- a/common/userpref.c
+++ b/common/userpref.c
@@ -24,6 +24,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "src\msc_config.h"
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/common/utils.c
+++ b/common/utils.c
@@ -23,6 +23,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "src\msc_config.h"
+#endif
+
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
@@ -34,7 +38,7 @@
 #include "utils.h"
 
 #ifdef _MSC_VER
-#include "msc_compat.h"
+#include "src\msc_compat.h"
 #endif
 
 #ifndef HAVE_STPCPY

--- a/common/utils.c
+++ b/common/utils.c
@@ -33,6 +33,10 @@
 
 #include "utils.h"
 
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
+
 #ifndef HAVE_STPCPY
 /**
  * Copy characters from one string into another

--- a/src/afc.c
+++ b/src/afc.c
@@ -24,6 +24,10 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -33,6 +37,10 @@
 #include "idevice.h"
 #include "common/debug.h"
 #include "endianness.h"
+
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
 
 /**
  * Locks an AFC client, done for thread safety stuff

--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -22,6 +22,11 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #define _GNU_SOURCE 1
@@ -33,6 +38,10 @@
 #include "common/debug.h"
 #include "common/utils.h"
 #include "asprintf.h"
+
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
 
 /**
  * Convert a service_error_t value to a debugserver_error_t value.

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -50,6 +50,10 @@
 #include "common/thread.h"
 #include "common/debug.h"
 
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
+
 #ifdef HAVE_OPENSSL
 static mutex_t *mutex_buf = NULL;
 static void locking_function(int mode, int n, const char* file, int line)

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -20,6 +20,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -29,6 +33,10 @@
 #include "installation_proxy.h"
 #include "property_list_service.h"
 #include "common/debug.h"
+
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
 
 typedef enum {
 	INSTPROXY_COMMAND_TYPE_ASYNC,

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -26,6 +26,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "msc_config.h"
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #define _GNU_SOURCE 1

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -61,6 +61,10 @@
 #define sleep(x) Sleep(x*1000)
 #endif
 
+#ifdef _MSC_VER
+#include "src\msc_compat.h"
+#endif
+
 /**
  * Convert an error string identifier to a lockdownd_error_t value.
  * Used internally to get correct error codes from a response.

--- a/src/mobilesync.c
+++ b/src/mobilesync.c
@@ -32,6 +32,10 @@
 #include "device_link_service.h"
 #include "common/debug.h"
 
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
+
 #define MSYNC_VERSION_INT1 300
 #define MSYNC_VERSION_INT2 100
 

--- a/src/msc_compat.h
+++ b/src/msc_compat.h
@@ -1,0 +1,26 @@
+/*
+* msc_comapt.c
+* Contains definitions that will help the Visual C++ compiler compile
+* the libimobiledevice code base. Overrides existing definitions,
+* so this file must be included at the end.
+*
+* Copyright (c) 2015 Frederik Carlier, Quamotion bvba. All Rights Reserved.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef _MSC_VER
+#define strdup _strdup
+#endif

--- a/src/msc_config.h
+++ b/src/msc_config.h
@@ -23,4 +23,6 @@
 #ifdef _MSC_VER
 #define inline __inline
 #define _CRT_SECURE_NO_WARNINGS
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#define __func__ __FUNCTION__
 #endif

--- a/src/msc_config.h
+++ b/src/msc_config.h
@@ -1,0 +1,26 @@
+/*
+* config_msc.c
+* Contains definitions that will help the Visual C++ compiler compile
+* the libimobiledevice code base.
+*
+* Copyright (c) 2015 Frederik Carlier, Quamotion bvba. All Rights Reserved.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef _MSC_VER
+#define inline __inline
+#define _CRT_SECURE_NO_WARNINGS
+#endif

--- a/src/restore.c
+++ b/src/restore.c
@@ -32,6 +32,10 @@
 #define RESULT_SUCCESS 0
 #define RESULT_FAILURE 1
 
+#ifdef _MSC_VER
+#include "msc_compat.h"
+#endif
+
 /**
  * Internally used function for checking the result from restore's answer
  * plist to a previously sent request.


### PR DESCRIPTION
This pull request fixes incompatibilities between the Visual C++ compiler and the libimobiledevice codebase.

It consists of two changes:
- A `msc_config.h` file, which defines values such as `_CRT_SECURE_NO_WARNINGS` which work around Visual C++ compiler errors, and defines macros, functions,... that don't exist when compiling with the Visual C++ compiler. For example, **func** is defined as **FUNCTION**.. This header must be included before any other header is included in the file; it is usually added right after the `config.h` header.
- A `msc_compat.h` file, which overrides function definitions in C++ that create compiler errors. For example, using `strdup` in Visual C++ creates an error asking you to use `_strdup` instead. This file defines `strdup` as `_strdup`, working around the issue.

The updated code compiles on Linux (see [Travis Build](https://travis-ci.org/libimobiledevice-win32/libimobiledevice/builds/59106620) ) and Windows (see [AppVeyor Build](https://ci.appveyor.com/project/qmfrederik/libimobiledevice) )
