### PR TITLE
 Visual C++ Compatibility: Fix public headers, #includes

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -19,14 +19,28 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifdef _MSC_VER
+#include "src\msc_config.h"
+#endif
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <errno.h>
-#include <sys/time.h>
 #include <sys/stat.h>
+
+#ifdef _MSC_VER
+#include <winsock2.h> 
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <sys/time.h>
+#endif
+
 #ifdef WIN32
 #include <winsock2.h>
 #include <windows.h>

--- a/common/userpref.c
+++ b/common/userpref.c
@@ -34,7 +34,6 @@
 #ifndef WIN32
 #include <pwd.h>
 #endif
-#include <unistd.h>
 #include <usbmuxd.h>
 #ifdef HAVE_OPENSSL
 #include <openssl/pem.h>

--- a/common/utils.c
+++ b/common/utils.c
@@ -27,7 +27,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#ifdef _MSC_VER
+#include <winsock2.h>
+#else
 #include <sys/time.h>
+#endif
+
 #include <inttypes.h>
 #include <ctype.h>
 

--- a/include/libimobiledevice/afc.h
+++ b/include/libimobiledevice/afc.h
@@ -106,7 +106,7 @@ typedef afc_client_private *afc_client_t; /**< The client handle. */
  *         invalid, AFC_E_MUX_ERROR if the connection cannot be established,
  *         or AFC_E_NO_MEM if there is a memory allocation problem.
  */
-afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t *client);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t *client);
 
 /**
  * Starts a new AFC service on the specified device and connects to it.
@@ -119,7 +119,7 @@ afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t serv
  *
  * @return AFC_E_SUCCESS on success, or an AFC_E_* error code otherwise.
  */
-afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, const char* label);
 
 /**
  * Frees up an AFC client. If the connection was created by the client itself,
@@ -127,7 +127,7 @@ afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, con
  *
  * @param client The client to free.
  */
-afc_error_t afc_client_free(afc_client_t client);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_client_free(afc_client_t client);
 
 /**
  * Get device information for a connected client. The device information
@@ -141,7 +141,7 @@ afc_error_t afc_client_free(afc_client_t client);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_device_info(afc_client_t client, char ***device_information);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_get_device_info(afc_client_t client, char ***device_information);
 
 /**
  * Gets a directory listing of the directory requested.
@@ -154,7 +154,7 @@ afc_error_t afc_get_device_info(afc_client_t client, char ***device_information)
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information);
 
 /**
  * Gets information about a specific file.
@@ -167,7 +167,7 @@ afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***di
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_file_info(afc_client_t client, const char *filename, char ***file_information);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_get_file_info(afc_client_t client, const char *filename, char ***file_information);
 
 /**
  * Opens a file on the device.
@@ -179,7 +179,7 @@ afc_error_t afc_get_file_info(afc_client_t client, const char *filename, char **
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle);
 
 /**
  * Closes a file on the device.
@@ -187,7 +187,7 @@ afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mo
  * @param client The client to close the file with.
  * @param handle File handle of a previously opened file.
  */
-afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
 
 /**
  * Locks or unlocks a file on the device.
@@ -201,7 +201,7 @@ afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
  *        AFC_LOCK_SH (shared lock), AFC_LOCK_EX (exclusive lock), or
  *        AFC_LOCK_UN (unlock).
  */
-afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation);
 
 /**
  * Attempts to the read the given number of bytes from the given file.
@@ -214,7 +214,7 @@ afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t op
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read);
 
 /**
  * Writes a given number of bytes to a file.
@@ -227,7 +227,7 @@ afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written);
 
 /**
  * Seeks to a given position of a pre-opened file on the device.
@@ -239,7 +239,7 @@ afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *dat
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence);
 
 /**
  * Returns current position in a pre-opened file on the device.
@@ -250,7 +250,7 @@ afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, 
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position);
 
 /**
  * Sets the size of a file on the device.
@@ -264,7 +264,7 @@ afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *positi
  * @note This function is more akin to ftruncate than truncate, and truncate
  *       calls would have to open the file before calling this, sadly.
  */
-afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize);
 
 /**
  * Deletes a file or directory.
@@ -274,7 +274,7 @@ afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t new
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_remove_path(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_remove_path(afc_client_t client, const char *path);
 
 /**
  * Renames a file or directory on the device.
@@ -285,7 +285,7 @@ afc_error_t afc_remove_path(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to);
 
 /**
  * Creates a directory on the device.
@@ -296,7 +296,7 @@ afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *t
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_make_directory(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_make_directory(afc_client_t client, const char *path);
 
 /**
  * Sets the size of a file on the device without prior opening it.
@@ -307,7 +307,7 @@ afc_error_t afc_make_directory(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize);
 
 /**
  * Creates a hard link or symbolic link on the device.
@@ -319,7 +319,7 @@ afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname);
 
 /**
  * Sets the modification time of a file on the device.
@@ -330,7 +330,7 @@ afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const c
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime);
 
 /**
  * Deletes a file or directory including possible contents.
@@ -342,7 +342,7 @@ afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mt
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
 
 /* Helper functions */
 
@@ -357,7 +357,7 @@ afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value);
 
 /**
  * Frees up a char dictionary as returned by some AFC functions.
@@ -366,7 +366,7 @@ afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char *
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_dictionary_free(char **dictionary);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_dictionary_free(char **dictionary);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/debugserver.h
+++ b/include/libimobiledevice/debugserver.h
@@ -62,7 +62,7 @@ typedef debugserver_command_private *debugserver_command_t; /**< The command han
  * @return DEBUGSERVER_E_SUCCESS on success, DEBUGSERVER_E_INVALID_ARG when
  *     client is NULL, or an DEBUGSERVER_E_* error code otherwise.
  */
-debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t * client);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t * client);
 
 /**
  * Starts a new debugserver service on the specified device and connects to it.
@@ -77,7 +77,7 @@ debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_d
  * @return DEBUGSERVER_E_SUCCESS on success, or an DEBUGSERVER_E_* error
  *     code otherwise.
  */
-debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label);
 
 /**
  * Disconnects a debugserver client from the device and frees up the
@@ -88,7 +88,7 @@ debugserver_error_t debugserver_client_start_service(idevice_t device, debugserv
  * @return DEBUGSERVER_E_SUCCESS on success, DEBUGSERVER_E_INVALID_ARG when
  *     client is NULL, or an DEBUGSERVER_E_* error code otherwise.
  */
-debugserver_error_t debugserver_client_free(debugserver_client_t client);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_free(debugserver_client_t client);
 
 /**
  * Sends raw data using the given debugserver service client.
@@ -103,7 +103,7 @@ debugserver_error_t debugserver_client_free(debugserver_client_t client);
  *      invalid, or DEBUGSERVER_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent);
 
 /**
  * Receives raw data using the given debugserver client with specified timeout.
@@ -120,7 +120,7 @@ debugserver_error_t debugserver_client_send(debugserver_client_t client, const c
  *      occurs, or DEBUGSERVER_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives raw data from the debugserver service.
@@ -134,7 +134,7 @@ debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client or plist is NULL
  */
-debugserver_error_t debugserver_client_receive(debugserver_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_receive(debugserver_client_t client, char *data, uint32_t size, uint32_t *received);
 
 /**
  * Sends a command to the debugserver service.
@@ -146,7 +146,7 @@ debugserver_error_t debugserver_client_receive(debugserver_client_t client, char
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client or command is NULL
  */
-debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response);
 
 /**
  * Receives and parses response of debugserver service.
@@ -157,7 +157,7 @@ debugserver_error_t debugserver_client_send_command(debugserver_client_t client,
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response);
 
 /**
  * Controls status of ACK mode when sending commands or receiving responses.
@@ -171,7 +171,7 @@ debugserver_error_t debugserver_client_receive_response(debugserver_client_t cli
  * @return DEBUGSERVER_E_SUCCESS on success, or an DEBUGSERVER_E_* error
  *     code otherwise.
  */
-debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled);
 
 /**
  * Sets the argv which launches an app.
@@ -184,7 +184,7 @@ debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client,
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response);
 
 /**
  * Adds or sets an environment variable.
@@ -196,7 +196,7 @@ debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response);
 
 /**
  * Creates and initializes a new command object.
@@ -209,7 +209,7 @@ debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_c
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when name or command is NULL
  */
-debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command);
 
 /**
  * Frees memory of command object.
@@ -219,7 +219,7 @@ debugserver_error_t debugserver_command_new(const char* name, int argc, char* ar
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when command is NULL
  */
-debugserver_error_t debugserver_command_free(debugserver_command_t command);
+LIBIMOBILEDEVICE_API_MSC debugserver_error_t debugserver_command_free(debugserver_command_t command);
 
 /**
  * Encodes a string into hex notation.
@@ -228,7 +228,7 @@ debugserver_error_t debugserver_command_free(debugserver_command_t command);
  * @param encoded_buffer The buffer receives a hex encoded string
  * @param encoded_length Length of the hex encoded string
  */
-void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length);
+LIBIMOBILEDEVICE_API_MSC void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length);
 
 /**
  * Decodes a hex encoded string.
@@ -237,7 +237,7 @@ void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32
  * @param encoded_length Length of the encoded buffer
  * @param buffer Decoded string to be freed by the caller
  */
-void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer);
+LIBIMOBILEDEVICE_API_MSC void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/diagnostics_relay.h
+++ b/include/libimobiledevice/diagnostics_relay.h
@@ -66,7 +66,7 @@ typedef diagnostics_relay_client_private *diagnostics_relay_client_t; /**< The c
  *     DIAGNOSTICS_RELAY_E_INVALID_ARG when one of the parameters is invalid,
  *     or DIAGNOSTICS_RELAY_E_MUX_ERROR when the connection failed.
  */
-diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client);
 
 /**
  * Starts a new diagnostics_relay service on the specified device and connects to it.
@@ -81,7 +81,7 @@ diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdow
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success, or an DIAGNOSTICS_RELAY_E_* error
  *     code otherwise.
  */
-diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t* client, const char* label);
 
 /**
  * Disconnects a diagnostics_relay client from the device and frees up the
@@ -94,7 +94,7 @@ diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t devic
  *     is invalid, or DIAGNOSTICS_RELAY_E_UNKNOWN_ERROR when the was an
  *     error freeing the parent property_list_service client.
  */
-diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client);
 
 
 /**
@@ -107,7 +107,7 @@ diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client);
 
 /**
  * Puts the device into deep sleep mode and disconnects from host.
@@ -119,7 +119,7 @@ diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t c
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client);
 
 /**
  * Restart the device and optionally show a user notification.
@@ -136,7 +136,7 @@ diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t cli
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, int flags);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, int flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.
@@ -153,7 +153,7 @@ diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t c
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, int flags);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, int flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.
@@ -170,13 +170,13 @@ diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t 
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics);
 
-diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result);
 
-diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* name, const char* class, plist_t* result);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* name, const char* class, plist_t* result);
 
-diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result);
+LIBIMOBILEDEVICE_API_MSC diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/file_relay.h
+++ b/include/libimobiledevice/file_relay.h
@@ -61,7 +61,7 @@ typedef file_relay_client_private *file_relay_client_t; /**< The client handle. 
  *     FILE_RELAY_E_INVALID_ARG when one of the parameters is invalid,
  *     or FILE_RELAY_E_MUX_ERROR when the connection failed.
  */
-file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client);
+LIBIMOBILEDEVICE_API_MSC file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client);
 
 /**
  * Starts a new file_relay service on the specified device and connects to it.
@@ -76,7 +76,7 @@ file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_des
  * @return FILE_RELAY_E_SUCCESS on success, or an FILE_RELAY_E_* error
  *     code otherwise.
  */
-file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t* client, const char* label);
 
 /**
  * Disconnects a file_relay client from the device and frees up the file_relay
@@ -89,7 +89,7 @@ file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_
  *     is invalid, or FILE_RELAY_E_UNKNOWN_ERROR when the was an error
  *     freeing the parent property_list_service client.
  */
-file_relay_error_t file_relay_client_free(file_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC file_relay_error_t file_relay_client_free(file_relay_client_t client);
 
 
 /**
@@ -123,7 +123,7 @@ file_relay_error_t file_relay_client_free(file_relay_client_t client);
  *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
  *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
  */
-file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection);
+LIBIMOBILEDEVICE_API_MSC file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection);
 
 /**
  * Request data for the given sources. Calls file_relay_request_sources_timeout() with
@@ -156,7 +156,7 @@ file_relay_error_t file_relay_request_sources(file_relay_client_t client, const 
  *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
  *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
  */
-file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/heartbeat.h
+++ b/include/libimobiledevice/heartbeat.h
@@ -57,7 +57,7 @@ typedef heartbeat_client_private *heartbeat_client_t; /**< The client handle. */
  * @return HEARTBEAT_E_SUCCESS on success, HEARTBEAT_E_INVALID_ARG when
  *     client is NULL, or an HEARTBEAT_E_* error code otherwise.
  */
-heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client);
 
 /**
  * Starts a new heartbeat service on the specified device and connects to it.
@@ -72,7 +72,7 @@ heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descr
  * @return HEARTBEAT_E_SUCCESS on success, or an HEARTBEAT_E_* error
  *     code otherwise.
  */
-heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label);
 
 /**
  * Disconnects a heartbeat client from the device and frees up the
@@ -83,7 +83,7 @@ heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_cli
  * @return HEARTBEAT_E_SUCCESS on success, HEARTBEAT_E_INVALID_ARG when
  *     client is NULL, or an HEARTBEAT_E_* error code otherwise.
  */
-heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
 
 
 /**
@@ -95,7 +95,7 @@ heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
  * @return HEARTBEAT_E_SUCCESS on success,
  *  HEARTBEAT_E_INVALID_ARG when client or plist is NULL
  */
-heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -106,7 +106,7 @@ heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
  * @return HEARTBEAT_E_SUCCESS on success,
  *  HEARTBEAT_E_INVALID_ARG when client or plist is NULL
  */
-heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
 
 /**
  * Receives a plist using the given heartbeat client.
@@ -123,7 +123,7 @@ heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
  *      communication error occurs, or HEARTBEAT_E_UNKNOWN_ERROR
  *      when an unspecified error occurs.
  */
-heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms);
+LIBIMOBILEDEVICE_API_MSC heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/house_arrest.h
+++ b/include/libimobiledevice/house_arrest.h
@@ -60,7 +60,7 @@ typedef house_arrest_client_private *house_arrest_client_t; /**< The client hand
  * @return HOUSE_ARREST_E_SUCCESS on success, HOUSE_ARREST_E_INVALID_ARG when
  *     client is NULL, or an HOUSE_ARREST_E_* error code otherwise.
  */
-house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client);
 
 /**
  * Starts a new house_arrest service on the specified device and connects to it.
@@ -75,7 +75,7 @@ house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service
  * @return HOUSE_ARREST_E_SUCCESS on success, or an HOUSE_ARREST_E_* error
  *     code otherwise.
  */
-house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t* client, const char* label);
 
 /**
  * Disconnects an house_arrest client from the device and frees up the
@@ -91,7 +91,7 @@ house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_a
  * @return HOUSE_ARREST_E_SUCCESS on success, HOUSE_ARREST_E_INVALID_ARG when
  *     client is NULL, or an HOUSE_ARREST_E_* error code otherwise.
  */
-house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
 
 
 /**
@@ -111,7 +111,7 @@ house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occured.
  */
-house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict);
 
 /**
  * Send a command to the connected house_arrest service.
@@ -132,7 +132,7 @@ house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, pli
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occured.
  */
-house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid);
 
 /**
  * Retrieves the result of a previously sent house_arrest_request_* request.
@@ -148,7 +148,7 @@ house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, con
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occured.
  */
-house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict);
+LIBIMOBILEDEVICE_API_MSC house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict);
 
 
 /**
@@ -170,7 +170,7 @@ house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist
  *     an afc client, or an AFC_E_* error code returned by
  *     afc_client_new_with_service_client().
  */
-afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/installation_proxy.h
+++ b/include/libimobiledevice/installation_proxy.h
@@ -126,7 +126,7 @@ typedef void (*instproxy_status_cb_t) (plist_t command, plist_t status, void *us
  * @return INSTPROXY_E_SUCCESS on success, or an INSTPROXY_E_* error value
  *         when an error occured.
  */
-instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client);
 
 /**
  * Starts a new installation_proxy service on the specified device and connects to it.
@@ -141,7 +141,7 @@ instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descr
  * @return INSTPROXY_E_SUCCESS on success, or an INSTPROXY_E_* error
  *         code otherwise.
  */
-instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label);
 
 /**
  * Disconnects an installation_proxy client from the device and frees up the
@@ -152,7 +152,7 @@ instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_cli
  * @return INSTPROXY_E_SUCCESS on success
  *         or INSTPROXY_E_INVALID_ARG if client is NULL.
  */
-instproxy_error_t instproxy_client_free(instproxy_client_t client);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_client_free(instproxy_client_t client);
 
 /**
  * List installed applications. This function runs synchronously.
@@ -170,7 +170,7 @@ instproxy_error_t instproxy_client_free(instproxy_client_t client);
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occured.
  */
-instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result);
 
 /**
  * List pages of installed applications in a callback.
@@ -189,7 +189,7 @@ instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_opt
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occured.
  */
-instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Lookup information about specific applications from the device.
@@ -205,7 +205,7 @@ instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plis
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occured.
  */
-instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result);
 
 /**
  * Install an application on the device.
@@ -231,7 +231,7 @@ instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appid
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Upgrade an application on the device. This function is nearly the same as
@@ -259,7 +259,7 @@ instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_p
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Uninstall an application from the device.
@@ -280,7 +280,7 @@ instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_p
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * List archived applications. This function runs synchronously.
@@ -296,7 +296,7 @@ instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *app
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occured.
  */
-instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result);
 
 /**
  * Archive an application on the device.
@@ -322,7 +322,7 @@ instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t c
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Restore a previously archived application on the device.
@@ -346,7 +346,7 @@ instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Removes a previously archived application from the device.
@@ -369,7 +369,7 @@ instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid
  *       created successfully; any error occuring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Checks a device for certain capabilities.
@@ -385,7 +385,7 @@ instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occured.
  */
-instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result);
 
 /* Helper */
 
@@ -395,7 +395,7 @@ instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, 
  * @param command The dictionary describing the command.
  * @param name Pointer to store the name of the command.
  */
-void instproxy_command_get_name(plist_t command, char** name);
+LIBIMOBILEDEVICE_API_MSC void instproxy_command_get_name(plist_t command, char** name);
 
 /**
  * Gets the name of a status.
@@ -403,7 +403,7 @@ void instproxy_command_get_name(plist_t command, char** name);
  * @param status The dictionary status response to use.
  * @param name Pointer to store the name of the status.
  */
-void instproxy_status_get_name(plist_t status, char **name);
+LIBIMOBILEDEVICE_API_MSC void instproxy_status_get_name(plist_t status, char **name);
 
 /**
  * Gets error name, code and description from a response if available.
@@ -419,7 +419,7 @@ void instproxy_status_get_name(plist_t status, char **name);
  * @return INSTPROXY_E_SUCCESS if no error is found or an INSTPROXY_E_* error
  *   value matching the error that ẃas found in the status.
  */
-instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code);
 
 /**
  * Gets total and current item information from a browse response if available.
@@ -434,7 +434,7 @@ instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char**
  *        If NULL is passed no list will be returned. If NULL is returned no
  *        list was found in the status.
  */
-void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list);
+LIBIMOBILEDEVICE_API_MSC void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list);
 
 
 /**
@@ -444,14 +444,14 @@ void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t
  * @param name Pointer to store the progress in percent (0-100) or -1 if not
  *        progress was found in the status.
  */
-void instproxy_status_get_percent_complete(plist_t status, int *percent);
+LIBIMOBILEDEVICE_API_MSC void instproxy_status_get_percent_complete(plist_t status, int *percent);
 
 /**
  * Creates a new client_options plist.
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t instproxy_client_options_new(void);
+LIBIMOBILEDEVICE_API_MSC plist_t instproxy_client_options_new(void);
 
 /**
  * Adds one or more new key:value pairs to the given client_options.
@@ -463,7 +463,7 @@ plist_t instproxy_client_options_new(void);
  *       keys "ApplicationSINF", "iTunesMetadata", "ReturnAttributes" which are
  *       expecting a plist_t node as value and "SkipUninstall" expects int.
  */
-void instproxy_client_options_add(plist_t client_options, ...);
+LIBIMOBILEDEVICE_API_MSC void instproxy_client_options_add(plist_t client_options, ...);
 
 /**
  * Adds attributes to the given client_options to filter browse results.
@@ -473,7 +473,7 @@ void instproxy_client_options_add(plist_t client_options, ...);
  *
  * @note The values passed are expected to be strings.
  */
-void instproxy_client_options_set_return_attributes(plist_t client_options, ...);
+LIBIMOBILEDEVICE_API_MSC void instproxy_client_options_set_return_attributes(plist_t client_options, ...);
 
 /**
  * Frees client_options plist.
@@ -481,7 +481,7 @@ void instproxy_client_options_set_return_attributes(plist_t client_options, ...)
  * @param client_options The client options plist to free. Does nothing if NULL
  *        is passed.
  */
-void instproxy_client_options_free(plist_t client_options);
+LIBIMOBILEDEVICE_API_MSC void instproxy_client_options_free(plist_t client_options);
 
 /**
  * Queries the device for the path of an application.
@@ -495,7 +495,7 @@ void instproxy_client_options_free(plist_t client_options);
  *         the path could not be determined or an INSTPROXY_E_* error
  *         value if an error occured.
  */
-instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* bundle_id, char** path);
+LIBIMOBILEDEVICE_API_MSC instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* bundle_id, char** path);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -25,6 +25,17 @@
 #ifndef IMOBILEDEVICE_H
 #define IMOBILEDEVICE_H
 
+// Visual C++ requires the declaration of the methods to be exactly the same in
+// the public headers and the source files; otherwise it throws C2375.
+// Other compilers don't care.
+// In the .c files, we use the LIBIMOBILEDEVICE_API definition which depends on 
+// other definitions from config.h. We can't reference config.h from public headers.
+#ifdef _MSC_VER
+#define LIBIMOBILEDEVICE_API_MSC __declspec( dllexport )
+#else 
+#define LIBIMOBILEDEVICE_API_MSC
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,7 +88,7 @@ typedef void (*idevice_event_cb_t) (const idevice_event_t *event, void *user_dat
  *
  * @param level Set to 0 for no debug output or 1 to enable debug output.
  */
-void idevice_set_debug_level(int level);
+LIBIMOBILEDEVICE_API_MSC void idevice_set_debug_level(int level);
 
 /**
  * Register a callback function that will be called when device add/remove
@@ -89,7 +100,7 @@ void idevice_set_debug_level(int level);
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occured.
  */
-idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data);
 
 /**
  * Release the event callback function that has been registered with
@@ -97,7 +108,7 @@ idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occured.
  */
-idevice_error_t idevice_event_unsubscribe(void);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_event_unsubscribe(void);
 
 /* discovery (synchronous) */
 
@@ -110,7 +121,7 @@ idevice_error_t idevice_event_unsubscribe(void);
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occured.
  */
-idevice_error_t idevice_get_device_list(char ***devices, int *count);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_get_device_list(char ***devices, int *count);
 
 /**
  * Free a list of device udids.
@@ -119,7 +130,7 @@ idevice_error_t idevice_get_device_list(char ***devices, int *count);
  *
  * @return Always returnes IDEVICE_E_SUCCESS.
  */
-idevice_error_t idevice_device_list_free(char **devices);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_device_list_free(char **devices);
 
 /* device structure creation and destruction */
 
@@ -136,7 +147,7 @@ idevice_error_t idevice_device_list_free(char **devices);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_new(idevice_t *device, const char *udid);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_new(idevice_t *device, const char *udid);
 
 /**
  * Cleans up an idevice structure, then frees the structure itself.
@@ -145,7 +156,7 @@ idevice_error_t idevice_new(idevice_t *device, const char *udid);
  *
  * @param device idevice_t to free.
  */
-idevice_error_t idevice_free(idevice_t device);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_free(idevice_t device);
 
 /* connection/disconnection */
 
@@ -159,7 +170,7 @@ idevice_error_t idevice_free(idevice_t device);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection);
 
 /**
  * Disconnect from the device and clean up the connection structure.
@@ -168,7 +179,7 @@ idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connect
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_disconnect(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_disconnect(idevice_connection_t connection);
 
 /* communication */
 
@@ -183,7 +194,7 @@ idevice_error_t idevice_disconnect(idevice_connection_t connection);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes);
 
 /**
  * Receive data from a device via the given connection.
@@ -200,7 +211,7 @@ idevice_error_t idevice_connection_send(idevice_connection_t connection, const c
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
 
 /**
  * Receive data from a device via the given connection.
@@ -215,7 +226,7 @@ idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connecti
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes);
 
 /**
  * Enables SSL for the given connection.
@@ -226,7 +237,7 @@ idevice_error_t idevice_connection_receive(idevice_connection_t connection, char
  *     is NULL or connection->ssl_data is non-NULL, or IDEVICE_E_SSL_ERROR when
  *     SSL initialization, setup, or handshake fails.
  */
-idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
 
 /**
  * Disable SSL for the given connection.
@@ -237,19 +248,19 @@ idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
  *     is NULL. This function also returns IDEVICE_E_SUCCESS when SSL is not
  *     enabled and does no further error checking on cleanup.
  */
-idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
 
 /* misc */
 
 /**
  * Gets the handle of the device. Depends on the connection type.
  */
-idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle);
 
 /**
  * Gets the unique id for the device.
  */
-idevice_error_t idevice_get_udid(idevice_t device, char **udid);
+LIBIMOBILEDEVICE_API_MSC idevice_error_t idevice_get_udid(idevice_t device, char **udid);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/lockdown.h
+++ b/include/libimobiledevice/lockdown.h
@@ -112,7 +112,7 @@ typedef struct lockdownd_service_descriptor *lockdownd_service_descriptor_t;
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label);
 
 /**
  * Creates a new lockdownd client for the device and starts initial handshake.
@@ -131,7 +131,7 @@ lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *cli
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL,
  *  LOCKDOWN_E_INVALID_CONF if configuration data is wrong
  */
-lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label);
 
 /**
  * Closes the lockdownd client session if one is running and frees up the
@@ -141,7 +141,7 @@ lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdown
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
 
 
 /**
@@ -153,7 +153,7 @@ lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
 
 /**
  * Retrieves a preferences plist using an optional domain and/or key name.
@@ -165,7 +165,7 @@ lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value);
 
 /**
  * Sets a preferences value using a plist and optional by domain and/or key name.
@@ -178,7 +178,7 @@ lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *dom
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  value is NULL
  */
-lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value);
 
 /**
  * Removes a preference node by domain and/or key name.
@@ -191,7 +191,7 @@ lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *dom
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key);
 
 /**
  * Requests to start a service and retrieve it's port on success.
@@ -205,7 +205,7 @@ lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *
  *  by the device, LOCKDOWN_E_START_SERVICE_FAILED if the service could not be
  *  started by the device
  */
-lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
 
 /**
  * Requests to start a service and retrieve it's port on success.
@@ -221,7 +221,7 @@ lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char 
  *  started by the device, LOCKDOWN_E_INVALID_CONF if the host id or escrow bag are
  *  missing from the device record.
  */
-lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
 
 /**
  * Opens a session with lockdownd and switches to SSL mode if device wants it.
@@ -236,7 +236,7 @@ lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t cli
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the supplied HostID,
  *  LOCKDOWN_E_SSL_ERROR if enabling SSL communication failed
  */
-lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled);
 
 /**
  * Closes the lockdownd session by sending the StopSession request.
@@ -248,7 +248,7 @@ lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char 
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id);
 
 /**
  * Sends a plist to lockdownd.
@@ -262,7 +262,7 @@ lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  plist is NULL
  */
-lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
 
 /**
  * Receives a plist from lockdownd.
@@ -273,7 +273,7 @@ lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  plist is NULL
  */
-lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
 
 /**
  * Pairs the device using the supplied pair record.
@@ -289,7 +289,7 @@ lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
 /**
  * Validates if the device is paired with the given HostID. If successful the
@@ -308,7 +308,7 @@ lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_recor
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
 /**
  * Unpairs the device with the given HostID and removes the pairing records
@@ -324,7 +324,7 @@ lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_p
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
 /**
  * Activates the device. Only works within an open session.
@@ -341,7 +341,7 @@ lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_rec
  *  LOCKDOWN_E_INVALID_ACTIVATION_RECORD if the device reports that the
  *  activation_record is invalid
  */
-lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record);
 
 /**
  * Deactivates the device, returning it to the locked “Activate with iTunes”
@@ -353,7 +353,7 @@ lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activati
  *  LOCKDOWN_E_NO_RUNNING_SESSION if no session is open,
  *  LOCKDOWN_E_PLIST_ERROR if the received plist is broken
  */
-lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
 
 /**
  * Tells the device to immediately enter recovery mode.
@@ -362,7 +362,7 @@ lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
 
 /**
  * Sends the Goodbye request to lockdownd signaling the end of communication.
@@ -373,7 +373,7 @@ lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
  *  is NULL, LOCKDOWN_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
 
 /* Helper */
 
@@ -384,7 +384,7 @@ lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
  * @param label The label to set or NULL to disable sending a label
  *
  */
-void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
+LIBIMOBILEDEVICE_API_MSC void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
 
 /**
  * Returns the unique id of the device from lockdownd.
@@ -395,7 +395,7 @@ void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t control, char **udid);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t control, char **udid);
 
 /**
  * Retrieves the name of the device from lockdownd set by the user.
@@ -406,7 +406,7 @@ lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t control, char **u
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name);
 
 /**
  * Calculates and returns the data classes the device supports from lockdownd.
@@ -421,7 +421,7 @@ lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **de
  *  LOCKDOWN_E_NO_RUNNING_SESSION if no session is open,
  *  LOCKDOWN_E_PLIST_ERROR if the received plist is broken
  */
-lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count);
 
 /**
  * Frees memory of an allocated array of data classes as returned by lockdownd_get_sync_data_classes()
@@ -430,7 +430,7 @@ lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, cha
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_data_classes_free(char **classes);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_data_classes_free(char **classes);
 
 /**
  * Frees memory of a service descriptor as returned by lockdownd_start_service()
@@ -439,7 +439,7 @@ lockdownd_error_t lockdownd_data_classes_free(char **classes);
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service);
+LIBIMOBILEDEVICE_API_MSC lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/misagent.h
+++ b/include/libimobiledevice/misagent.h
@@ -59,7 +59,7 @@ typedef misagent_client_private *misagent_client_t; /**< The client handle. */
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is NULL, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client);
 
 /**
  * Starts a new misagent service on the specified device and connects to it.
@@ -74,7 +74,7 @@ misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descrip
  * @return MISAGENT_E_SUCCESS on success, or an MISAGENT_E_* error
  *     code otherwise.
  */
-misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t* client, const char* label);
 
 /**
  * Disconnects an misagent client from the device and frees up the
@@ -85,7 +85,7 @@ misagent_error_t misagent_client_start_service(idevice_t device, misagent_client
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is NULL, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_client_free(misagent_client_t client);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_client_free(misagent_client_t client);
 
 
 /**
@@ -98,7 +98,7 @@ misagent_error_t misagent_client_free(misagent_client_t client);
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is invalid, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
 
 /**
  * Retrieves an array of all installed provisioning profiles.
@@ -114,7 +114,7 @@ misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
  *     still returns MISAGENT_E_SUCCESS and profiles will just point to an
  *     empty array.
  */
-misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
 
 /**
  * Removes a given provisioning profile.
@@ -127,7 +127,7 @@ misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is invalid, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_remove(misagent_client_t client, const char* profileID);
+LIBIMOBILEDEVICE_API_MSC misagent_error_t misagent_remove(misagent_client_t client, const char* profileID);
 
 /**
  * Retrieves the status code from the last operation.
@@ -136,7 +136,7 @@ misagent_error_t misagent_remove(misagent_client_t client, const char* profileID
  *
  * @return -1 if client is invalid, or the status code from the last operation
  */
-int misagent_get_status_code(misagent_client_t client);
+LIBIMOBILEDEVICE_API_MSC int misagent_get_status_code(misagent_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobile_image_mounter.h
+++ b/include/libimobiledevice/mobile_image_mounter.h
@@ -24,6 +24,11 @@
 #ifndef IMOBILE_IMAGE_MOUNTER_H
 #define IMOBILE_IMAGE_MOUNTER_H
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -64,7 +69,7 @@ typedef ssize_t (*mobile_image_mounter_upload_cb_t) (void* buffer, size_t length
  *    or MOBILE_IMAGE_MOUNTER_E_CONN_FAILED if the connection to the
  *    device could not be established.
  */
-mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client);
 
 /**
  * Starts a new mobile_image_mounter service on the specified device and connects to it.
@@ -79,7 +84,7 @@ mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdown
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success, or an MOBILE_IMAGE_MOUNTER_E_* error
  *     code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t* client, const char* label);
 
 /**
  * Disconnects a mobile_image_mounter client from the device and frees up the
@@ -90,7 +95,7 @@ mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success,
  *    or MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if client is NULL.
  */
-mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client);
 
 
 /**
@@ -106,7 +111,7 @@ mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_clie
  *
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success, or an error code on error
  */
-mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result);
 
 /**
  * Uploads an image with an optional signature to the device.
@@ -125,7 +130,7 @@ mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_moun
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on succes, or a
  *    MOBILE_IMAGE_MOUNTER_E_* error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata);
 
 /**
  * Mounts an image on the device.
@@ -148,7 +153,7 @@ mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_moun
  *    MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if on ore more parameters are
  *    invalid, or another error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result);
 
 /**
  * Hangs up the connection to the mobile_image_mounter service.
@@ -161,7 +166,7 @@ mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mount
  *     MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if client is invalid,
  *     or another error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilebackup.h
+++ b/include/libimobiledevice/mobilebackup.h
@@ -65,7 +65,7 @@ typedef enum {
  *     or more parameters are invalid, or DEVICE_LINK_SERVICE_E_BAD_VERSION if
  *     the mobilebackup version on the device is newer.
  */
-mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client);
 
 /**
  * Starts a new mobilebackup service on the specified device and connects to it.
@@ -80,7 +80,7 @@ mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service
  * @return MOBILEBACKUP_E_SUCCESS on success, or an MOBILEBACKUP_E_* error
  *     code otherwise.
  */
-mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilebackup client from the device and frees up the
@@ -91,7 +91,7 @@ mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobileb
  * @return MOBILEBACKUP_E_SUCCESS on success, or MOBILEBACKUP_E_INVALID_ARG
  *     if client is NULL.
  */
-mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
 
 
 /**
@@ -102,7 +102,7 @@ mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
  *
  * @return an error code
  */
-mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t *plist);
 
 /**
  * Sends mobilebackup data to the device
@@ -115,7 +115,7 @@ mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t 
  *
  * @return an error code
  */
-mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist);
 
 /**
  * Request a backup from the connected device.
@@ -134,7 +134,7 @@ mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t pli
  *    backup_manifest is not of type PLIST_DICT, MOBILEBACKUP_E_MUX_ERROR
  *    if a communication error occurs, MOBILEBACKUP_E_REPLY_NOT_OK
  */
-mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version);
 
 /**
  * Sends a confirmation to the device that a backup file has been received.
@@ -145,7 +145,7 @@ mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, p
  *    client is invalid, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client);
 
 /**
  * Request that a backup should be restored to the connected device.
@@ -168,7 +168,7 @@ mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_
  *    if a communication error occurs, or MOBILEBACKUP_E_REPLY_NOT_OK
  *    if the device did not accept the request.
  */
-mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version);
 
 /**
  * Receive a confirmation from the device that it successfully received
@@ -188,7 +188,7 @@ mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, 
  *    message plist, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result);
 
 /**
  * Receive a confirmation from the device that it successfully received
@@ -208,7 +208,7 @@ mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_cli
  *    message plist, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result);
 
 /**
  * Tells the device that the restore process is complete and waits for the
@@ -221,7 +221,7 @@ mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebac
  *    message plist is invalid, or MOBILEBACKUP_E_MUX_ERROR if a communication
  *    error occurs.
  */
-mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client);
 
 /**
  * Sends a backup error message to the device.
@@ -233,7 +233,7 @@ mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t cl
  *    one of the parameters is invalid, or MOBILEBACKUP_E_MUX_ERROR if a
  *    communication error occurs.
  */
-mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason);
+LIBIMOBILEDEVICE_API_MSC mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilebackup2.h
+++ b/include/libimobiledevice/mobilebackup2.h
@@ -61,7 +61,7 @@ typedef mobilebackup2_client_private *mobilebackup2_client_t; /**< The client ha
  *     if one or more parameter is invalid, or MOBILEBACKUP2_E_BAD_VERSION
  *     if the mobilebackup2 version on the device is newer.
  */
-mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup2_client_t * client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup2_client_t * client);
 
 /**
  * Starts a new mobilebackup2 service on the specified device and connects to it.
@@ -76,7 +76,7 @@ mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_servi
  * @return MOBILEBACKUP2_E_SUCCESS on success, or an MOBILEBACKUP2_E_* error
  *     code otherwise.
  */
-mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilebackup2 client from the device and frees up the
@@ -87,7 +87,7 @@ mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobil
  * @return MOBILEBACKUP2_E_SUCCESS on success, or MOBILEBACKUP2_E_INVALID_ARG
  *     if client is NULL.
  */
-mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
 
 
 /**
@@ -102,7 +102,7 @@ mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
  *     will be inserted into this plist before sending it. This parameter
  *     can be NULL if message is not NULL.
  */
-mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options);
 
 /**
  * Receives a DL* message plist from the device.
@@ -122,7 +122,7 @@ mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, 
  *    or is not a DL* message plist, or MOBILEBACKUP2_E_MUX_ERROR if
  *    receiving from the device failed.
  */
-mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage);
 
 /**
  * Send binary data to the device.
@@ -140,7 +140,7 @@ mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t clien
  *     MOBILEBACKUP2_E_INVALID_ARG if one of the parameters is invalid,
  *     or MOBILEBACKUP2_E_MUX_ERROR if sending of the data failed.
  */
-mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes);
 
 /**
  * Receive binary from the device.
@@ -160,7 +160,7 @@ mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, cons
  *     MOBILEBACKUP2_E_INVALID_ARG if one of the parameters is invalid,
  *     or MOBILEBACKUP2_E_MUX_ERROR if receiving the data failed.
  */
-mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes);
 
 /**
  * Performs the mobilebackup2 protocol version exchange.
@@ -173,7 +173,7 @@ mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, c
  * @return MOBILEBACKUP2_E_SUCCESS on success, or a MOBILEBACKUP2_E_* error
  *     code otherwise.
  */
-mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version);
 
 /**
  * Send a request to the connected mobilebackup2 service.
@@ -188,7 +188,7 @@ mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t clie
  * @return MOBILEBACKUP2_E_SUCCESS if the request was successfully sent,
  *     or a MOBILEBACKUP2_E_* error value otherwise.
  */
-mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options);
 
 /**
  * Sends a DLMessageStatusResponse to the device.
@@ -202,7 +202,7 @@ mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, 
  * @return MOBILEBACKUP2_E_SUCCESS on success, MOBILEBACKUP2_E_INVALID_ARG
  *     if client is invalid, or another MOBILEBACKUP2_E_* otherwise.
  */
-mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2);
+LIBIMOBILEDEVICE_API_MSC mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilesync.h
+++ b/include/libimobiledevice/mobilesync.h
@@ -81,7 +81,7 @@ typedef mobilesync_anchors *mobilesync_anchors_t; /**< Anchors used by the devic
  * @retval DEVICE_LINK_SERVICE_E_BAD_VERSION if the mobilesync version on
  * the device is newer.
  */
-mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilesync_client_t * client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilesync_client_t * client);
 
 /**
  * Starts a new mobilesync service on the specified device and connects to it.
@@ -96,7 +96,7 @@ mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_des
  * @return MOBILESYNC_E_SUCCESS on success, or an MOBILESYNC_E_* error
  *     code otherwise.
  */
-mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilesync client from the device and frees up the
@@ -107,7 +107,7 @@ mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if \a client is NULL.
  */
-mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
 
 
 /**
@@ -118,7 +118,7 @@ mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
  *
  * @return an error code
  */
-mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist);
 
 /**
  * Sends mobilesync data to the device
@@ -131,7 +131,7 @@ mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist
  *
  * @return an error code
  */
-mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
 
 
 /**
@@ -154,7 +154,7 @@ mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * sync request
  */
-mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description);
 
 /**
  * Cancels a running synchronization session with a device at any time.
@@ -165,7 +165,7 @@ mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason);
 
 /**
  * Finish a synchronization session of a data class on the device.
@@ -178,7 +178,7 @@ mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* rea
  * @retval MOBILESYNC_E_PLIST_ERROR if the received plist is not of valid
  * form
  */
-mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
 
 
 /**
@@ -191,7 +191,7 @@ mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client);
 
 /**
  * Requests to receive only changed records of the currently set data class from the device.
@@ -203,7 +203,7 @@ mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t cl
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client);
 
 /**
  * Requests the device to delete all records of the current data class
@@ -216,7 +216,7 @@ mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  * @retval MOBILESYNC_E_PLIST_ERROR if the received plist is not of valid form
  */
-mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client);
 
 
 /**
@@ -232,7 +232,7 @@ mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t cl
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * session
  */
-mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions);
 
 /**
  * Acknowledges to the device that the changes have been merged on the computer
@@ -242,7 +242,7 @@ mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client);
 
 
 /**
@@ -262,7 +262,7 @@ mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_
  * @retval MOBILESYNC_E_NOT_READY if the device is not ready to start
  * receiving any changes
  */
-mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client);
 
 
 /**
@@ -279,7 +279,7 @@ mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_cli
  * @retval MOBILESYNC_E_WRONG_DIRECTION if the current sync direction does
  * not permit this call
  */
-mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions);
 
 /**
  * Receives any remapped identifiers reported after the device merged submitted changes.
@@ -296,7 +296,7 @@ mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t e
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * session
  */
-mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping);
+LIBIMOBILEDEVICE_API_MSC mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping);
 
 /* Helper */
 
@@ -309,14 +309,14 @@ mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plis
  *
  * @return A new #mobilesync_anchors_t struct. Must be freed using mobilesync_anchors_free().
  */
-mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor);
+LIBIMOBILEDEVICE_API_MSC mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor);
 
 /**
  * Free memory used by anchors.
  *
  * @param anchors The anchors to free.
  */
-void mobilesync_anchors_free(mobilesync_anchors_t anchors);
+LIBIMOBILEDEVICE_API_MSC void mobilesync_anchors_free(mobilesync_anchors_t anchors);
 
 
 /**
@@ -324,7 +324,7 @@ void mobilesync_anchors_free(mobilesync_anchors_t anchors);
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t mobilesync_actions_new(void);
+LIBIMOBILEDEVICE_API_MSC plist_t mobilesync_actions_new(void);
 
 /**
  * Add one or more new key:value pairs to the given actions plist.
@@ -338,14 +338,14 @@ plist_t mobilesync_actions_new(void);
  *       integer to use as a boolean value indicating that the device should
  *       link submitted changes and report remapped identifiers.
  */
-void mobilesync_actions_add(plist_t actions, ...);
+LIBIMOBILEDEVICE_API_MSC void mobilesync_actions_add(plist_t actions, ...);
 
 /**
  * Free actions plist.
  *
  * @param actions The actions plist to free. Does nothing if NULL is passed.
  */
-void mobilesync_actions_free(plist_t actions);
+LIBIMOBILEDEVICE_API_MSC void mobilesync_actions_free(plist_t actions);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/notification_proxy.h
+++ b/include/libimobiledevice/notification_proxy.h
@@ -103,7 +103,7 @@ typedef void (*np_notify_cb_t) (const char *notification, void *user_data);
  *   or NP_E_CONN_FAILED when the connection to the device could not be
  *   established.
  */
-np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client);
 
 /**
  * Starts a new notification proxy service on the specified device and connects to it.
@@ -118,7 +118,7 @@ np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t servic
  * @return NP_E_SUCCESS on success, or an NP_E_* error
  *     code otherwise.
  */
-np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label);
 
 /**
  * Disconnects a notification_proxy client from the device and frees up the
@@ -128,7 +128,7 @@ np_error_t np_client_start_service(idevice_t device, np_client_t* client, const 
  *
  * @return NP_E_SUCCESS on success, or NP_E_INVALID_ARG when client is NULL.
  */
-np_error_t np_client_free(np_client_t client);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_client_free(np_client_t client);
 
 
 /**
@@ -139,7 +139,7 @@ np_error_t np_client_free(np_client_t client);
  *
  * @return NP_E_SUCCESS on success, or an error returned by np_plist_send
  */
-np_error_t np_post_notification(np_client_t client, const char *notification);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_post_notification(np_client_t client, const char *notification);
 
 /**
  * Tells the device to send a notification on the specified event.
@@ -150,7 +150,7 @@ np_error_t np_post_notification(np_client_t client, const char *notification);
  * @return NP_E_SUCCESS on success, NP_E_INVALID_ARG when client or
  *    notification are NULL, or an error returned by np_plist_send.
  */
-np_error_t np_observe_notification(np_client_t client, const char *notification);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_observe_notification(np_client_t client, const char *notification);
 
 /**
  * Tells the device to send a notification on specified events.
@@ -163,7 +163,7 @@ np_error_t np_observe_notification(np_client_t client, const char *notification)
  * @return NP_E_SUCCESS on success, NP_E_INVALID_ARG when client is null,
  *   or an error returned by np_observe_notification.
  */
-np_error_t np_observe_notifications(np_client_t client, const char **notification_spec);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_observe_notifications(np_client_t client, const char **notification_spec);
 
 /**
  * This function allows an application to define a callback function that will
@@ -187,7 +187,7 @@ np_error_t np_observe_notifications(np_client_t client, const char **notificatio
  *         NP_E_INVALID_ARG when client is NULL, or NP_E_UNKNOWN_ERROR when
  *         the callback thread could no be created.
  */
-np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *userdata);
+LIBIMOBILEDEVICE_API_MSC np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *userdata);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/property_list_service.h
+++ b/include/libimobiledevice/property_list_service.h
@@ -58,7 +58,7 @@ typedef property_list_service_private* property_list_service_client_t; /**< The 
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG when one of the arguments is invalid,
  *     or PROPERTY_LIST_SERVICE_E_MUX_ERROR when connecting to the device failed.
  */
-property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client);
 
 /**
  * Frees a PropertyList service.
@@ -69,7 +69,7 @@ property_list_service_error_t property_list_service_client_new(idevice_t device,
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG when client is invalid, or a
  *     PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when another error occured.
  */
-property_list_service_error_t property_list_service_client_free(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_client_free(property_list_service_client_t client);
 
 /**
  * Sends an XML plist.
@@ -82,7 +82,7 @@ property_list_service_error_t property_list_service_client_free(property_list_se
  *      PROPERTY_LIST_SERVICE_E_PLIST_ERROR when dict is not a valid plist,
  *      or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist);
 
 /**
  * Sends a binary plist.
@@ -95,7 +95,7 @@ property_list_service_error_t property_list_service_send_xml_plist(property_list
  *      PROPERTY_LIST_SERVICE_E_PLIST_ERROR when dict is not a valid plist,
  *      or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist);
 
 /**
  * Receives a plist using the given property list service client with specified
@@ -114,7 +114,7 @@ property_list_service_error_t property_list_service_send_binary_plist(property_l
  *      communication error occurs, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when
  *      an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout);
 
 /**
  * Receives a plist using the given property list service client.
@@ -135,7 +135,7 @@ property_list_service_error_t property_list_service_receive_plist_with_timeout(p
  *      communication error occurs, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when
  *      an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist);
 
 /**
  * Enable SSL for the given property list service client.
@@ -148,7 +148,7 @@ property_list_service_error_t property_list_service_receive_plist(property_list_
  *     NULL, PROPERTY_LIST_SERVICE_E_SSL_ERROR when SSL could not be enabled,
  *     or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client);
 
 /**
  * Disable SSL for the given property list service client.
@@ -160,7 +160,7 @@ property_list_service_error_t property_list_service_enable_ssl(property_list_ser
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG if client or client->connection is
  *     NULL, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API_MSC property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/restore.h
+++ b/include/libimobiledevice/restore.h
@@ -59,7 +59,7 @@ typedef restored_client_private *restored_client_t; /**< The client handle. */
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label);
 
 /**
  * Closes the restored client session if one is running and frees up the
@@ -69,7 +69,7 @@ restored_error_t restored_client_new(idevice_t device, restored_client_t *client
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_client_free(restored_client_t client);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_client_free(restored_client_t client);
 
 
 /**
@@ -82,7 +82,7 @@ restored_error_t restored_client_free(restored_client_t client);
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version);
 
 /**
  * Queries a value from the device specified by a key.
@@ -93,7 +93,7 @@ restored_error_t restored_query_type(restored_client_t client, char **type, uint
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL, RESTORE_E_PLIST_ERROR if value for key can't be found
  */
-restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value);
 
 /**
  * Retrieves a value from information plist specified by a key.
@@ -104,7 +104,7 @@ restored_error_t restored_query_value(restored_client_t client, const char *key,
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL, RESTORE_E_PLIST_ERROR if value for key can't be found
  */
-restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value) ;
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value) ;
 
 /**
  * Sends a plist to restored.
@@ -118,7 +118,7 @@ restored_error_t restored_get_value(restored_client_t client, const char *key, p
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client or
  *  plist is NULL
  */
-restored_error_t restored_send(restored_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_send(restored_client_t client, plist_t plist);
 
 /**
  * Receives a plist from restored.
@@ -129,7 +129,7 @@ restored_error_t restored_send(restored_client_t client, plist_t plist);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client or
  *  plist is NULL
  */
-restored_error_t restored_receive(restored_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_receive(restored_client_t client, plist_t *plist);
 
 /**
  * Sends the Goodbye request to restored signaling the end of communication.
@@ -139,7 +139,7 @@ restored_error_t restored_receive(restored_client_t client, plist_t *plist);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL,
  *  RESTORE_E_PLIST_ERROR if the device did not acknowledge the request
  */
-restored_error_t restored_goodbye(restored_client_t client);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_goodbye(restored_client_t client);
 
 
 /**
@@ -152,7 +152,7 @@ restored_error_t restored_goodbye(restored_client_t client);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG if a parameter
  *  is NULL, RESTORE_E_START_RESTORE_FAILED if the request fails
  */
-restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version);
 
 /**
  * Requests device to reboot.
@@ -162,7 +162,7 @@ restored_error_t restored_start_restore(restored_client_t client, plist_t option
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG if a parameter
  *  is NULL
  */
-restored_error_t restored_reboot(restored_client_t client);
+LIBIMOBILEDEVICE_API_MSC restored_error_t restored_reboot(restored_client_t client);
 
 /* Helper */
 
@@ -173,7 +173,7 @@ restored_error_t restored_reboot(restored_client_t client);
  * @param label The label to set or NULL to disable sending a label
  *
  */
-void restored_client_set_label(restored_client_t client, const char *label);
+LIBIMOBILEDEVICE_API_MSC void restored_client_set_label(restored_client_t client, const char *label);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/sbservices.h
+++ b/include/libimobiledevice/sbservices.h
@@ -69,7 +69,7 @@ typedef sbservices_client_private *sbservices_client_t; /**< The client handle. 
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client);
 
 /**
  * Starts a new sbservices service on the specified device and connects to it.
@@ -84,7 +84,7 @@ sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_des
  * @return SBSERVICES_E_SUCCESS on success, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t* client, const char* label);
 
 /**
  * Disconnects an sbservices client from the device and frees up the
@@ -95,7 +95,7 @@ sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_client_free(sbservices_client_t client);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_client_free(sbservices_client_t client);
 
 
 /**
@@ -112,7 +112,7 @@ sbservices_error_t sbservices_client_free(sbservices_client_t client);
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or state is invalid, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version);
 
 /**
  * Sets the icon state of the connected device.
@@ -123,7 +123,7 @@ sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or newstate is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate);
 
 /**
  * Get the icon of the specified app as PNG data.
@@ -140,7 +140,7 @@ sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t
  *     client, bundleId, or pngdata are invalid, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize);
 
 /**
  * Gets the interface orientation of the device.
@@ -151,7 +151,7 @@ sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or state is invalid, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation);
 
 /**
  * Get the home screen wallpaper as PNG data.
@@ -167,7 +167,7 @@ sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t clie
  *     client or pngdata are invalid, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
+LIBIMOBILEDEVICE_API_MSC sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/screenshotr.h
+++ b/include/libimobiledevice/screenshotr.h
@@ -63,7 +63,7 @@ typedef screenshotr_client_private *screenshotr_client_t; /**< The client handle
  *     or more parameters are invalid, or SCREENSHOTR_E_CONN_FAILED if the
  *     connection to the device could not be established.
  */
-screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service, screenshotr_client_t * client);
+LIBIMOBILEDEVICE_API_MSC screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service, screenshotr_client_t * client);
 
 /**
  * Starts a new screenshotr service on the specified device and connects to it.
@@ -78,7 +78,7 @@ screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_d
  * @return SCREENSHOTR_E_SUCCESS on success, or an SCREENSHOTR_E_* error
  *     code otherwise.
  */
-screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API_MSC screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t* client, const char* label);
 
 /**
  * Disconnects a screenshotr client from the device and frees up the
@@ -89,7 +89,7 @@ screenshotr_error_t screenshotr_client_start_service(idevice_t device, screensho
  * @return SCREENSHOTR_E_SUCCESS on success, or SCREENSHOTR_E_INVALID_ARG
  *     if client is NULL.
  */
-screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
+LIBIMOBILEDEVICE_API_MSC screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
 
 
 /**
@@ -106,7 +106,7 @@ screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
  *     one or more parameters are invalid, or another error code if an
  *     error occured.
  */
-screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
+LIBIMOBILEDEVICE_API_MSC screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/service.h
+++ b/include/libimobiledevice/service.h
@@ -59,7 +59,7 @@ typedef service_client_private* service_client_t; /**< The client handle. */
  *     SERVICE_E_INVALID_ARG when one of the arguments is invalid,
  *     or SERVICE_E_MUX_ERROR when connecting to the device failed.
  */
-service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client);
 
 /**
  * Starts a new service on the specified device with given name and
@@ -76,7 +76,7 @@ service_error_t service_client_new(idevice_t device, lockdownd_service_descripto
  * @return SERVICE_E_SUCCESS on success, or a SERVICE_E_* error code
  *     otherwise.
  */
-service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code);
 
 /**
  * Frees a service instance.
@@ -87,7 +87,7 @@ service_error_t service_client_factory_start_service(idevice_t device, const cha
  *     SERVICE_E_INVALID_ARG when client is invalid, or a
  *     SERVICE_E_UNKNOWN_ERROR when another error occured.
  */
-service_error_t service_client_free(service_client_t client);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_client_free(service_client_t client);
 
 
 /**
@@ -103,7 +103,7 @@ service_error_t service_client_free(service_client_t client);
  *      invalid, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_send(service_client_t client, const char *data, uint32_t size, uint32_t *sent);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_send(service_client_t client, const char *data, uint32_t size, uint32_t *sent);
 
 /**
  * Receives data using the given service client with specified timeout.
@@ -120,7 +120,7 @@ service_error_t service_send(service_client_t client, const char *data, uint32_t
  *      occurs, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_receive_with_timeout(service_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_receive_with_timeout(service_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives data using the given service client.
@@ -136,7 +136,7 @@ service_error_t service_receive_with_timeout(service_client_t client, char *data
  *      occurs, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_receive(service_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_receive(service_client_t client, char *data, uint32_t size, uint32_t *received);
 
 
 /**
@@ -149,7 +149,7 @@ service_error_t service_receive(service_client_t client, char *data, uint32_t si
  *     NULL, SERVICE_E_SSL_ERROR when SSL could not be enabled,
  *     or SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-service_error_t service_enable_ssl(service_client_t client);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_enable_ssl(service_client_t client);
 
 /**
  * Disable SSL for the given service client.
@@ -160,7 +160,7 @@ service_error_t service_enable_ssl(service_client_t client);
  *     SERVICE_E_INVALID_ARG if client or client->connection is
  *     NULL, or SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-service_error_t service_disable_ssl(service_client_t client);
+LIBIMOBILEDEVICE_API_MSC service_error_t service_disable_ssl(service_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/syslog_relay.h
+++ b/include/libimobiledevice/syslog_relay.h
@@ -61,7 +61,7 @@ typedef void (*syslog_relay_receive_cb_t)(char c, void *user_data);
  * @return SYSLOG_RELAY_E_SUCCESS on success, SYSLOG_RELAY_E_INVALID_ARG when
  *     client is NULL, or an SYSLOG_RELAY_E_* error code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client);
 
 /**
  * Starts a new syslog_relay service on the specified device and connects to it.
@@ -76,7 +76,7 @@ syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service
  * @return SYSLOG_RELAY_E_SUCCESS on success, or an SYSLOG_RELAY_E_* error
  *     code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label);
 
 /**
  * Disconnects a syslog_relay client from the device and frees up the
@@ -87,7 +87,7 @@ syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_
  * @return SYSLOG_RELAY_E_SUCCESS on success, SYSLOG_RELAY_E_INVALID_ARG when
  *     client is NULL, or an SYSLOG_RELAY_E_* error code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
 
 
 /**
@@ -104,7 +104,7 @@ syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
  *      invalid or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs or a syslog capture has already been started.
  */
-syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
 
 /**
  * Stops capturing the syslog of the device.
@@ -118,7 +118,7 @@ syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, sy
  *      invalid or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs or a syslog capture has already been started.
  */
-syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
 
 /* Receiving */
 
@@ -137,7 +137,7 @@ syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
  *      occurs, or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives data from the service.
@@ -151,7 +151,7 @@ syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t cli
  * @return SYSLOG_RELAY_E_SUCCESS on success,
  *  SYSLOG_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API_MSC syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/webinspector.h
+++ b/include/libimobiledevice/webinspector.h
@@ -59,7 +59,7 @@ typedef webinspector_client_private *webinspector_client_t; /**< The client hand
  * @return WEBINSPECTOR_E_SUCCESS on success, WEBINSPECTOR_E_INVALID_ARG when
  *     client is NULL, or an WEBINSPECTOR_E_* error code otherwise.
  */
-webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client);
 
 /**
  * Starts a new webinspector service on the specified device and connects to it.
@@ -74,7 +74,7 @@ webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service
  * @return WEBINSPECTOR_E_SUCCESS on success, or an WEBINSPECTOR_E_* error
  *     code otherwise.
  */
-webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label);
 
 /**
  * Disconnects a webinspector client from the device and frees up the
@@ -85,7 +85,7 @@ webinspector_error_t webinspector_client_start_service(idevice_t device, webinsp
  * @return WEBINSPECTOR_E_SUCCESS on success, WEBINSPECTOR_E_INVALID_ARG when
  *     client is NULL, or an WEBINSPECTOR_E_* error code otherwise.
  */
-webinspector_error_t webinspector_client_free(webinspector_client_t client);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_client_free(webinspector_client_t client);
 
 
 /**
@@ -97,7 +97,7 @@ webinspector_error_t webinspector_client_free(webinspector_client_t client);
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success,
  *  DIAGNOSTICS_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -108,7 +108,7 @@ webinspector_error_t webinspector_send(webinspector_client_t client, plist_t pli
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success,
  *  DIAGNOSTICS_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist);
 
 /**
  * Receives a plist using the given webinspector client.
@@ -125,7 +125,7 @@ webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t 
  *      communication error occurs, or WEBINSPECTOR_E_UNKNOWN_ERROR
  *      when an unspecified error occurs.
  */
-webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms);
+LIBIMOBILEDEVICE_API_MSC webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/src/afc.c
+++ b/src/afc.c
@@ -26,7 +26,6 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 
 #include "afc.h"

--- a/src/afc.h
+++ b/src/afc.h
@@ -106,6 +106,6 @@ enum {
 	AFC_OP_FILE_WRITE_OFFSET         = 0x00000028	/* FileRefWriteWithOffset */
 };
 
-afc_error_t afc_client_new_with_service_client(service_client_t service_client, afc_client_t *client);
+LIBIMOBILEDEVICE_API_MSC afc_error_t afc_client_new_with_service_client(service_client_t service_client, afc_client_t *client);
 
 #endif

--- a/src/house_arrest.c
+++ b/src/house_arrest.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <plist/plist.h>
 
 #include "house_arrest.h"

--- a/src/idevice.h
+++ b/src/idevice.h
@@ -33,6 +33,14 @@
 #include <gnutls/x509.h>
 #endif
 
+#ifdef _MSC_VER
+// Visual C++ requires the declaration of methods to be exactly the same
+// in the .h and .c files; otherwise it throws C2375. 
+// In libimobiledevice.h, we always prefix the methods with __declspec( dllexport ) 
+// through the LIBIMOBILEDEVICE_API_MSC definition.
+// We mimic that behavior here.
+#define LIBIMOBILEDEVICE_API __declspec( dllexport )
+#else
 #ifdef WIN32
 #define LIBIMOBILEDEVICE_API __declspec( dllexport )
 #else
@@ -40,6 +48,7 @@
 #define LIBIMOBILEDEVICE_API __attribute__((visibility("default")))
 #else
 #define LIBIMOBILEDEVICE_API
+#endif
 #endif
 #endif
 

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -23,7 +23,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
-#include <unistd.h>
 #include <plist/plist.h>
 
 #include "installation_proxy.h"

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -32,7 +32,6 @@
 #define __USE_GNU 1
 #include <stdio.h>
 #include <ctype.h>
-#include <unistd.h>
 #ifdef HAVE_OPENSSL
 #include <openssl/pem.h>
 #include <openssl/x509.h>

--- a/src/misagent.c
+++ b/src/misagent.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <plist/plist.h>
 #include <stdio.h>
 

--- a/src/mobile_image_mounter.c
+++ b/src/mobile_image_mounter.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <plist/plist.h>
 
 #include "mobile_image_mounter.h"

--- a/src/notification_proxy.c
+++ b/src/notification_proxy.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <plist/plist.h>
 
 #include "notification_proxy.h"
@@ -30,6 +29,8 @@
 
 #ifdef WIN32
 #define sleep(x) Sleep(x*1000)
+#else
+#include <unistd.h>
 #endif
 
 struct np_thread {

--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -21,7 +21,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <plist/plist.h>
 
 #include "sbservices.h"


### PR DESCRIPTION
This pull request fixes incompatibilities between the Visual C++ compiler and the libimobiledevice codebase.

It consists of two changes:
- In all the public headers, the function definitions are now prefixed by `LIBIMOBILEDEVICE_API_MSC`. On the current codebase, Visual C++ generates a compiler C2375 because the function declarations in the public header and the source files differ; for example `afc_error_t afc_client_free(afc_client_t client)` vs `__declspec( dllexport ) afc_error_t afc_client_free(afc_client_t client)`.
  Recyling `LIBIMOBILEDEVICE_API` in the public headers doesn't work, because it value depends on what is defined in `config.h`, and that's specific to the libimobiledevice build, not what the user is building.
  Instead, a new define `LIBIMOBILEDEVICE_API_MSC` is used which adds the `__declspec( dllexport )` prefix only if Visual C++ is used. `LIBIMOBILEDEVICE_API` is updated to always be `__declspec( dllexport )` when compiling with Visual C++.
-  Some `#include` statements were not compatibile with Visual C++ and this has been fixed. A lot of `unistd.h` includes were redundant and the have been removed.

The updated code compiles on Linux (see [Travis Build](https://travis-ci.org/libimobiledevice-win32/libimobiledevice/builds/59106620) ) and Windows (see [AppVeyor Build](https://ci.appveyor.com/project/qmfrederik/libimobiledevice) )
