### PR TITLE
Fix loading imobiledevice.so (import imobiledevice) in Python 3

### DIFF
--- a/cython/debugserver.pxi
+++ b/cython/debugserver.pxi
@@ -44,7 +44,11 @@ cdef class DebugServerError(BaseError):
 
 
 # from http://stackoverflow.com/a/17511714
-from cpython.string cimport PyString_AsString
+from cpython cimport PY_MAJOR_VERSION
+if PY_MAJOR_VERSION <= 2:
+    from cpython.string cimport PyString_AsString
+else:
+    from cpython.bytes cimport PyBytes_AsString as PyString_AsString
 cdef char ** to_cstring_array(list_str):
     if not list_str:
         return NULL
@@ -92,7 +96,7 @@ cdef class DebugServerClient(BaseService):
     def __cinit__(self, iDevice device = None, LockdownServiceDescriptor descriptor = None, *args, **kwargs):
         if (device is not None and descriptor is not None):
             self.handle_error(debugserver_client_new(device._c_dev, descriptor._c_service_descriptor, &(self._c_client)))
-    
+
     def __dealloc__(self):
         cdef debugserver_error_t err
         if self._c_client is not NULL:


### PR DESCRIPTION
`PyString_AsString` is now basically [`PyBytes_AsString`](https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString) in Python 3. Without this, if you `import imobiledevice` you get a symbol lookup error.

On Linux:

```
>>> import sys
>>> sys.version
'3.4.1 (default, Feb 14 2015, 22:35:37) \n[GCC 4.8.3]'
>>> import imobiledevice
ImportError: /usr/lib64/python3.4/site-packages/imobiledevice.so: undefined symbol: PyString_AsString
```

Now I am not saying Python 3 support is completely fixed, at all (see below). This just makes the module load.

```
>>> u = imobiledevice.get_device_list()[0]
>>> d = imobiledevice.iDevice(u)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "imobiledevice.pyx", line 177, in imobiledevice.iDevice.__cinit__ (imobiledevice.c:7230)
TypeError: iDevice's constructor takes a string or None as the udid argument
```

There is a lot of work in a lot of places (Lockdown class) to fix for Python 3 and still retain full compatibility with Python 2.
