### PR TITLE
configure.ac: Don't always explicitly disable openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AC_SUBST([CYTHON_SUB])
 AC_ARG_ENABLE([openssl],
             [AS_HELP_STRING([--disable-openssl],
             [Do not look for OpenSSL])],
-            [use_openssl=no],
+            [use_openssl=$enableval],
             [use_openssl=yes])
 
 pkg_req_openssl="openssl >= 0.9.8"


### PR DESCRIPTION
This changes configure.ac to use a more correct usage of `AC_ARG_ENABLE`.
Right now openssl is disabled if you pass any form of` --enable-openssl`, `--disable-openssl`,
etc. This fixes that and only disables openssl if you pass `--disable-openssl`.