### PR TITLE
configure.ac: remove run-time test for large files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,16 +182,6 @@ LFS_CFLAGS=''
 if test "$enable_largefile" != no; then
     if test "$ac_cv_sys_file_offset_bits" != 'no'; then
 	LFS_CFLAGS="$LFS_CFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
-    else
-	AC_MSG_CHECKING(for native large file support)
-	AC_RUN_IFELSE([AC_LANG_SOURCE([#include <unistd.h>
-	  int main (int argc, char **argv)
-	  {
-	      exit(!(sizeof(off_t) == 8));
-	  }])],
-	[ac_cv_sys_file_offset_bits=64; AC_DEFINE(_FILE_OFFSET_BITS,64)
-	 AC_MSG_RESULT(yes)],
-	[AC_MSG_RESULT(no)])
     fi
     if test "$ac_cv_sys_large_files" != 'no'; then
 	LFS_CFLAGS="$LFS_CFLAGS -D_LARGE_FILES=1"


### PR DESCRIPTION
Following error occurred when building libimobiledevice
from openembedded with MACHINE=qemux86-x64:

configure:17888: checking for native large file support
configure:17891: error: in `/home/jenkins/oe/shr-core-branches/shr-core/tmp-eglibc/work/core2-64-oe-linux/libimobiledevice/1.1.4-r0/libimobiledevice-1.1.4':
configure:17893: error: cannot run test program while cross compiling

configure.ac was already using AC_SYS_LARGEFILE macro as is typical, but
then there was an extra runtime check added beyond that: check if off_t
is 8 bytes (64 bits) long. If that runtime check passed,
define _FILE_OFFSET_BITS as 64.

Runtime checks need to be avoided for cross-compiling environments
such as openembedded, and luckily this extra check was not needed.
Note that off_t is already 64 bits in the native 64-bit case,
_without_ setting _FILE_OFFSET_BITS, so just leave _FILE_OFFSET_BITS
undefined if configure code from AC_SYS_LARGEFILE does not set it.
