### PR TITLE
Changes for upstream

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -33,6 +33,8 @@
 #include <stdio.h>
 #include <plist/plist.h>
 
+#define MAC_EPOCH 978307200
+
 #ifndef HAVE_STPCPY
 char *stpcpy(char *s1, const char *s2);
 #endif

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -239,6 +239,16 @@ idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
  */
 idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
 
+/**
+ * Get the underlying file descriptor for a connection
+ *
+ * @param connection The connection to get fd of
+ * @param fd Pointer to an int where the fd is stored
+ *
+ * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
+ */
+idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd);
+
 /* misc */
 
 /**

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -463,6 +463,22 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive(idevice_connecti
 	return internal_connection_receive(connection, data, len, recv_bytes);
 }
 
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd)
+{
+	if (!connection || !fd) {
+		return IDEVICE_E_INVALID_ARG;
+	}
+
+	idevice_error_t result = IDEVICE_E_UNKNOWN_ERROR;
+	if (connection->type == CONNECTION_USBMUXD) {
+		*fd = (int)(long)connection->data;
+		result = IDEVICE_E_SUCCESS;
+	} else {
+		debug_info("Unknown connection type %d", connection->type);
+	}
+	return result;
+}
+
 LIBIMOBILEDEVICE_API idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle)
 {
 	if (!device)

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -847,11 +847,12 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_status_get_error(plist_t status
 
 LIBIMOBILEDEVICE_API void instproxy_status_get_name(plist_t status, char **name)
 {
-	*name = NULL;
 	if (name) {
 		plist_t node = plist_dict_get_item(status, "Status");
 		if (node) {
 			plist_get_string_val(node, name);
+		} else {
+			*name = NULL;
 		}
 	}
 }
@@ -907,10 +908,13 @@ LIBIMOBILEDEVICE_API void instproxy_status_get_current_list(plist_t status, uint
 
 LIBIMOBILEDEVICE_API void instproxy_command_get_name(plist_t command, char** name)
 {
-	*name = NULL;
-	plist_t node = plist_dict_get_item(command, "Command");
-	if (node) {
-		plist_get_string_val(node, name);
+	if (name) {
+		plist_t node = plist_dict_get_item(command, "Command");
+		if (node) {
+			plist_get_string_val(node, name);
+		} else {
+			*name = NULL;
+		}
 	}
 }
 

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -637,7 +637,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_name(lockdownd_clien
 
 LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label)
 {
-	if (!client)
+	if (!device || !client)
 		return LOCKDOWN_E_INVALID_ARG;
 
 	static struct lockdownd_service_descriptor service = {

--- a/tools/idevicebackup.c
+++ b/tools/idevicebackup.c
@@ -251,7 +251,7 @@ static plist_t mobilebackup_factory_info_plist_new(const char* udid)
 	if (value_node)
 		plist_dict_set_item(ret, "IMEI", plist_copy(value_node));
 
-	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL), 0));
+	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL) - MAC_EPOCH, 0));
 
 	value_node = plist_dict_get_item(root_node, "ProductType");
 	plist_dict_set_item(ret, "Product Type", plist_copy(value_node));
@@ -288,7 +288,7 @@ static void mobilebackup_info_update_last_backup_date(plist_t info_plist)
 		return;
 
 	node = plist_dict_get_item(info_plist, "Last Backup Date");
-	plist_set_date_val(node, time(NULL), 0);
+	plist_set_date_val(node, time(NULL) - MAC_EPOCH, 0);
 
 	node = NULL;
 }

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -146,10 +146,10 @@ static void mobilebackup_afc_get_file_contents(afc_client_t afc, const char *fil
 		uint32_t bread = 0;
 		afc_file_read(afc, f, buf+done, 65536, &bread);
 		if (bread > 0) {
+			done += bread;
 		} else {
 			break;
 		}
-		done += bread;
 	}
 	if (done == fsize) {
 		*size = fsize;
@@ -223,7 +223,7 @@ static plist_t mobilebackup_factory_info_plist_new(const char* udid, lockdownd_c
 	if (value_node)
 		plist_dict_set_item(ret, "IMEI", plist_copy(value_node));
 
-	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL), 0));
+	plist_dict_set_item(ret, "Last Backup Date", plist_new_date(time(NULL) - MAC_EPOCH, 0));
 
 	value_node = plist_dict_get_item(root_node, "PhoneNumber");
 	if (value_node && (plist_get_node_type(value_node) == PLIST_STRING)) {
@@ -914,7 +914,8 @@ static void mb2_handle_list_directory(mobilebackup2_client_t mobilebackup2, plis
 				}
 				plist_dict_set_item(fdict, "DLFileType", plist_new_string(ftype));
 				plist_dict_set_item(fdict, "DLFileSize", plist_new_uint(st.st_size));
-				plist_dict_set_item(fdict, "DLFileModificationDate", plist_new_date(st.st_mtime, 0));
+				plist_dict_set_item(fdict, "DLFileModificationDate",
+						    plist_new_date(st.st_mtime - MAC_EPOCH, 0));
 
 				plist_dict_set_item(dirlist, ep->d_name, fdict);
 				free(fpath);


### PR DESCRIPTION
This set contains some small fixes and adding a new function to get the file descriptor of an idevice connection which will be needed for the improved fdr implementation in idevicerestore. Please pull or comment.