### PR TITLE
Update manpages with options from --help.

### DIFF
--- a/docs/idevicebackup2.1
+++ b/docs/idevicebackup2.1
@@ -31,6 +31,9 @@ prints usage information.
 .B backup
 create backup for the device.
 .TP
+.B \t\-\-full
+force full backup from device.
+.TP
 .B restore
 restore last backup to the device.
 .TP
@@ -58,11 +61,17 @@ show details about last completed backup of device.
 .B list
 list files of last completed backup in CSV format.
 .TP
+.B unback
+unpack a completed backup in DIRECTORY/_unback_/
+.TP
 .B encryption on|off [PWD]
 enable or disable backup encryption.
 .TP
 .B changepw [OLD NEW]
 change backup password on target device.
+.TP
+.B cloud on|off
+enable or disable cloud use (requires iCloud account)
 .SH AUTHORS
 Martin Szulecki
 

--- a/docs/ideviceinfo.1
+++ b/docs/ideviceinfo.1
@@ -14,6 +14,9 @@ Show information about the first connected device.
 .B \-d, \-\-debug
 enable communication debugging.
 .TP
+.B \-s, \-\-simple
+use a simple connection to avoid auto-pairing with the device.
+.TP
 .B \-u, \-\-udid UDID
 target specific device by its 40-digit device UDID.
 .TP


### PR DESCRIPTION
For idevicebackup2 and ideviceinfo.

I kept forgetting that `idevicebackup2 unback` was a thing I could do.

Differences highlighted using https://gist.github.com/pteromys/8e45072041afeb2922c0

Aside: I noticed that in 96101a1231a4ddfeb40fd738a24e108a3a904048, ideviceinfo's "the first connected device" became "a connected device" in `--help`. Maybe that ought to be updated in the manpage too, but I left it alone so that this commit could stay in the realm of mere copy+paste.
