### PR TITLE
cython: fixed notification_proxy callback gil lock

### DIFF
--- a/cython/lockdown.pxi
+++ b/cython/lockdown.pxi
@@ -210,14 +210,23 @@ cdef class LockdownClient(PropertyListService):
             raise
 
     cpdef set_value(self, bytes domain, bytes key, object value):
-        cdef plist.plist_t c_node = plist.native_to_plist_t(value)
+        cdef: 
+            plist.plist_t c_node = NULL
+            char* c_domain = NULL
+            char* c_key = NULL
+
+        c_node = plist.native_to_plist_t(value)
+        if domain is not None:
+            c_domain = domain
+        if key is not None:
+            c_key = key
         try:
-            self.handle_error(lockdownd_set_value(self._c_client, domain, key, c_node))
+            self.handle_error(lockdownd_set_value(self._c_client, c_domain, c_key, c_node))
         except BaseError, e:
             raise
         finally:
             if c_node != NULL:
-                plist.plist_free(c_node)
+                c_node = NULL
 
     cpdef remove_value(self, bytes domain, bytes key):
         self.handle_error(lockdownd_remove_value(self._c_client, domain, key))

--- a/cython/notification_proxy.pxi
+++ b/cython/notification_proxy.pxi
@@ -70,7 +70,7 @@ NP_ITDBPREP_DID_END = C_NP_ITDBPREP_DID_END
 NP_LANGUAGE_CHANGED = C_NP_LANGUAGE_CHANGED
 NP_ADDRESS_BOOK_PREF_CHANGED = C_NP_ADDRESS_BOOK_PREF_CHANGED
 
-cdef void np_notify_cb(const_char_ptr notification, void *py_callback):
+cdef void np_notify_cb(const_char_ptr notification, void *py_callback) with gil:
     (<object>py_callback)(notification)
 
 cdef class NotificationProxyError(BaseError):


### PR DESCRIPTION
- cython notification proxy bug segmentation fault when callback called
  without gil.
- added code to handle passing null values to `lockdown_set_value`, needed for  example when setting device name .
