### PR TITLE
Define a `diagnostics_relay_action_t` enum

### DIFF
--- a/include/libimobiledevice/diagnostics_relay.h
+++ b/include/libimobiledevice/diagnostics_relay.h
@@ -42,9 +42,11 @@ typedef enum {
 	DIAGNOSTICS_RELAY_E_UNKNOWN_ERROR   = -256
 } diagnostics_relay_error_t;
 
-#define DIAGNOSTICS_RELAY_ACTION_FLAG_WAIT_FOR_DISCONNECT (1 << 1)
-#define DIAGNOSTICS_RELAY_ACTION_FLAG_DISPLAY_PASS        (1 << 2)
-#define DIAGNOSTICS_RELAY_ACTION_FLAG_DISPLAY_FAIL        (1 << 3)
+typedef enum {
+    DIAGNOSTICS_RELAY_ACTION_FLAG_WAIT_FOR_DISCONNECT = 1 << 1,
+    DIAGNOSTICS_RELAY_ACTION_FLAG_DISPLAY_PASS = 1 << 2,
+    DIAGNOSTICS_RELAY_ACTION_FLAG_DISPLAY_FAIL = 1 << 3
+} diagnostics_relay_action_t;
 
 #define DIAGNOSTICS_RELAY_REQUEST_TYPE_ALL                "All"
 #define DIAGNOSTICS_RELAY_REQUEST_TYPE_WIFI               "WiFi"
@@ -136,7 +138,7 @@ diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t cli
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, int flags);
+diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.
@@ -153,7 +155,7 @@ diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t c
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, int flags);
+diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.

--- a/src/diagnostics_relay.c
+++ b/src/diagnostics_relay.c
@@ -228,7 +228,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_sleep(diagnosti
 	return ret;
 }
 
-static diagnostics_relay_error_t internal_diagnostics_relay_action(diagnostics_relay_client_t client, const char* name, int flags)
+static diagnostics_relay_error_t internal_diagnostics_relay_action(diagnostics_relay_client_t client, const char* name, diagnostics_relay_action_t flags)
 {
 	if (!client)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -272,12 +272,12 @@ static diagnostics_relay_error_t internal_diagnostics_relay_action(diagnostics_r
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, int flags)
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
 {
 	return internal_diagnostics_relay_action(client, "Restart", flags);
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, int flags)
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
 {
 	return internal_diagnostics_relay_action(client, "Shutdown", flags);
 }


### PR DESCRIPTION
Replace a bunch of constants which can be passed as flags with a single `diagnostics_relay_action_t` enum.

Amongst others, makes it easier to generate a .NET front-end for libimobiledevice.
