### PR TITLE
Ensure python3 compatibility

### DIFF
--- a/cython/debugserver.pxi
+++ b/cython/debugserver.pxi
@@ -49,8 +49,9 @@ cdef char ** to_cstring_array(list_str):
     if not list_str:
         return NULL
     cdef char **ret = <char **>malloc(len(list_str) * sizeof(char *))
-    for i in xrange(len(list_str)):
-        ret[i] = PyString_AsString(list_str[i])
+    cdef Py_ssize_t i
+    for i, s in enumerate(list_str):
+        ret[i] = s
     return ret
 
 
@@ -92,7 +93,7 @@ cdef class DebugServerClient(BaseService):
     def __cinit__(self, iDevice device = None, LockdownServiceDescriptor descriptor = None, *args, **kwargs):
         if (device is not None and descriptor is not None):
             self.handle_error(debugserver_client_new(device._c_dev, descriptor._c_service_descriptor, &(self._c_client)))
-    
+
     def __dealloc__(self):
         cdef debugserver_error_t err
         if self._c_client is not NULL:

--- a/cython/imobiledevice.pyx
+++ b/cython/imobiledevice.pyx
@@ -171,7 +171,7 @@ from libc.stdlib cimport *
 cdef class iDevice(Base):
     def __cinit__(self, object udid=None, *args, **kwargs):
         cdef char* c_udid = NULL
-        if isinstance(udid, basestring):
+        if isinstance(udid, bytes):
             c_udid = <bytes>udid
         elif udid is not None:
             raise TypeError("iDevice's constructor takes a string or None as the udid argument")

--- a/cython/lockdown.pxi
+++ b/cython/lockdown.pxi
@@ -230,9 +230,9 @@ cdef class LockdownClient(PropertyListService):
 
         if issubclass(service, BaseService) and \
             service.__service_name__ is not None \
-            and isinstance(service.__service_name__, basestring):
+            and isinstance(service.__service_name__, bytes):
             c_service_name = <bytes>service.__service_name__
-        elif isinstance(service, basestring):
+        elif isinstance(service, bytes):
             c_service_name = <bytes>service
         else:
             raise TypeError("LockdownClient.start_service() takes a BaseService or string as its first argument")
@@ -253,7 +253,7 @@ cdef class LockdownClient(PropertyListService):
 
         if not hasattr(service_class, '__service_name__') and \
             not service_class.__service_name__ is not None \
-            and not isinstance(service_class.__service_name__, basestring):
+            and not isinstance(service_class.__service_name__, bytes):
             raise TypeError("LockdownClient.get_service_client() takes a BaseService as its first argument")
 
         descriptor = self.start_service(service_class)


### PR DESCRIPTION
I tried to run the cython bindings on Python 3.5. There were some errors due to the stricter handling of strings vs bytes.

Therefore default everywhere to bytes.
