### PR TITLE
lockdown: Propagate lower level errors to callers instead of just returning unknown error

### DIFF
--- a/include/endianness.h
+++ b/include/endianness.h
@@ -27,6 +27,10 @@
 #endif
 #endif
 
+#ifndef htobe16
+#define htobe16 be16toh
+#endif
+
 #ifndef __bswap_32
 #define __bswap_32(x) ((((x) & 0xFF000000) >> 24) \
                     | (((x) & 0x00FF0000) >> 8) \

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -55,7 +55,8 @@ typedef idevice_connection_private *idevice_connection_t; /**< The connection ha
 /** The event type for device add or removal */
 enum idevice_event_type {
 	IDEVICE_DEVICE_ADD = 1,
-	IDEVICE_DEVICE_REMOVE
+	IDEVICE_DEVICE_REMOVE,
+	IDEVICE_DEVICE_PAIRED
 };
 
 /* event data structure */

--- a/include/libimobiledevice/lockdown.h
+++ b/include/libimobiledevice/lockdown.h
@@ -43,7 +43,7 @@ typedef enum {
 	LOCKDOWN_E_PAIRING_FAILED                          =  -4,
 	LOCKDOWN_E_SSL_ERROR                               =  -5,
 	LOCKDOWN_E_DICT_ERROR                              =  -6,
-	LOCKDOWN_E_NOT_ENOUGH_DATA                         =  -7,
+	LOCKDOWN_E_RECEIVE_TIMEOUT                         =  -7,
 	LOCKDOWN_E_MUX_ERROR                               =  -8,
 	LOCKDOWN_E_NO_RUNNING_SESSION                      =  -9,
 	/* native */

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -376,8 +376,8 @@ static idevice_error_t internal_connection_receive_timeout(idevice_connection_t 
 	if (connection->type == CONNECTION_USBMUXD) {
 		int res = usbmuxd_recv_timeout((int)(long)connection->data, data, len, recv_bytes, timeout);
 		if (res < 0) {
-			debug_info("ERROR: usbmuxd_recv_timeout returned %d (%s)", res, strerror(-res));
-			return IDEVICE_E_UNKNOWN_ERROR;
+			debug_info("ERROR: usbmuxd_recv_timeout returned %d (%s)", res, strerror(errno));
+			return (res == -EAGAIN ? IDEVICE_E_NOT_ENOUGH_DATA : IDEVICE_E_UNKNOWN_ERROR);
 		}
 		return IDEVICE_E_SUCCESS;
 	} else {

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -772,7 +772,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_remove_archive(instproxy_client
 
 LIBIMOBILEDEVICE_API instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result)
 {
-	if (!capabilities || (plist_get_node_type(capabilities) != PLIST_ARRAY && plist_get_node_type(capabilities) != PLIST_DICT))
+	if (!client || !capabilities || !result)
 		return INSTPROXY_E_INVALID_ARG;
 
 	plist_t lookup_result = NULL;

--- a/src/property_list_service.c
+++ b/src/property_list_service.c
@@ -98,7 +98,8 @@ LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_
  * @return PROPERTY_LIST_SERVICE_E_SUCCESS on success,
  *      PROPERTY_LIST_SERVICE_E_INVALID_ARG when one or more parameters are
  *      invalid, PROPERTY_LIST_SERVICE_E_PLIST_ERROR when dict is not a valid
- *      plist, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified
+ *      plist, PROPERTY_LIST_SERVICE_E_MUX_ERROR when a communication error
+ *      occurs, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
 static property_list_service_error_t internal_plist_send(property_list_service_client_t client, plist_t plist, int binary)
@@ -140,6 +141,7 @@ static property_list_service_error_t internal_plist_send(property_list_service_c
 	}
 	if (bytes <= 0) {
 		debug_info("ERROR: sending to device failed.");
+		res = PROPERTY_LIST_SERVICE_E_MUX_ERROR;
 	}
 
 	free(content);


### PR DESCRIPTION
Small patch to allow callers to get a better error code instead of just a generic error to know what went wrong.
