### PR TITLE
Provide access to idevice_connection for property_list_service

### DIFF
--- a/include/libimobiledevice/property_list_service.h
+++ b/include/libimobiledevice/property_list_service.h
@@ -162,6 +162,18 @@ property_list_service_error_t property_list_service_enable_ssl(property_list_ser
  */
 property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client);
 
+/**
+ * Get underlying idevice_connection of the given property list service client
+ *
+ * @param client The connected property list service client to get idevice_connection
+ * @param connection Pointer to an idevice_connection_t that will be filled
+ *   with the necessary data of the connection.
+ *
+ * @return PROPERTY_LIST_SERVICE_E_SUCCESS on success,
+ *     PROPERTY_LIST_SERVICE_E_INVALID_ARG if client or connection is NULL.
+ */
+property_list_service_error_t property_list_service_get_connection(property_list_service_client_t client, idevice_connection_t * connection);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/property_list_service.c
+++ b/src/property_list_service.c
@@ -274,3 +274,11 @@ LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_disable
 	return service_to_property_list_service_error(service_disable_ssl(client->parent));
 }
 
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_get_connection(property_list_service_client_t client, idevice_connection_t * connection)
+{
+	if (!client || !client->parent || !connection)
+		return PROPERTY_LIST_SERVICE_E_INVALID_ARG;
+	*connection = client->parent->connection;
+	return PROPERTY_LIST_SERVICE_E_SUCCESS;
+}
+


### PR DESCRIPTION
 Provide access to idevice_connection for property_list_service

```
Some services first expect a command as a property list, then pure data (e.g. a zip stream)
before sending a result again as a property list. Providing direct access to the
underlying idevice_connection avoids re-implementing the property list service serialization.
```
