### PR TITLE
On newer macOS versions, /var/db/lockdown/ is 700.

### DIFF
--- a/common/userpref.c
+++ b/common/userpref.c
@@ -192,35 +192,6 @@ int userpref_read_system_buid(char **system_buid)
 }
 
 /**
- * Determines whether this device has been connected to this system before.
- *
- * @param udid The device UDID as given by the device.
- *
- * @return 1 if the device has been connected previously to this configuration
- *         or 0 otherwise.
- */
-int userpref_has_pair_record(const char *udid)
-{
-	int ret = 0;
-	const char *config_path = NULL;
-	char *config_file = NULL;
-	struct stat st;
-
-	if (!udid) return 0;
-
-	/* first get config file */
-	config_path = userpref_get_config_dir();
-	config_file = string_concat(config_path, DIR_SEP_S, udid, USERPREF_CONFIG_EXTENSION, NULL);
-
-	if ((stat(config_file, &st) == 0) && S_ISREG(st.st_mode))
-		ret = 1;
-
-	free(config_file);
-
-	return ret;
-}
-
-/**
  * Fills a list with UDIDs of devices that have been connected to this
  * system before, i.e. for which a public key file exists.
  *

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -893,13 +893,9 @@ static lockdownd_error_t lockdownd_do_pair(lockdownd_client_t client, lockdownd_
 			lockdownd_get_value(client, NULL, "WiFiAddress", &wifi_node);
 		} else {
 			/* use existing pair record */
-			if (userpref_has_pair_record(client->udid)) {
-				userpref_read_pair_record(client->udid, &pair_record_plist);
-				if (!pair_record_plist) {
-					return LOCKDOWN_E_INVALID_CONF;
-				}
-			} else {
-				return LOCKDOWN_E_INVALID_HOST_ID;
+			userpref_read_pair_record(client->udid, &pair_record_plist);
+			if (!pair_record_plist) {
+				return LOCKDOWN_E_INVALID_CONF;
 			}
 		}
 	}


### PR DESCRIPTION
So, I've been working on tracking down a widely-reported LOCKDOWN_E_INVAILD_HOST_ID error while trying to do essentially anything. It seemed to mostly be affecting users of macOS 10.12, with a few people on OS X 10.11 (if so, probably only the absolute latest versions). Working with @conradev (who is actually running the latest version of macOS), we determined that the issue is that /var/db/lockdown is now mode 700, and so the code in lockdown.c for `userpref_has_pair_record` no longer works. (The only code which relies on that folder being accessible other than that function is `userpref_get_paired_udids`, which is only used by idevicepair as what is more of a low-level debugging tool.) The code in `lockdownd_do_pair` seriously is asking "is the record on disk? ok, let's ask for a copy from usbmuxd", so I simply removed the "is the record on disk?" part, as if it isn't there then we can expect usbmuxd to not return anything (right? ;P).