### PR TITLE
lockdown: return LOCKDOWN_E_INVALID_HOST_ID when missing pair record

### DIFF
--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -895,7 +895,7 @@ static lockdownd_error_t lockdownd_do_pair(lockdownd_client_t client, lockdownd_
 			/* use existing pair record */
 			userpref_read_pair_record(client->udid, &pair_record_plist);
 			if (!pair_record_plist) {
-				return LOCKDOWN_E_INVALID_CONF;
+				return LOCKDOWN_E_INVALID_HOST_ID;
 			}
 		}
 	}


### PR DESCRIPTION
When the check of /var/db/lockdown was removed, lockdownd_do_pair started to
always return LOCKDOWN_E_INVALID_CONF instead of usually (but not always...)
returning LOCKDOWN_E_INVALID_HOST_ID for devices not currently paired. This
change not only breaks some third-party code, but also breaks the other code
in this library calling this function (lockdownd_client_new_with_handshake).