### PR TITLE
Removing snapshot directories which failed during idevicebackup2 on iOS10

### DIFF
--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -1112,6 +1112,26 @@ static void clean_exit(int sig)
 	quit_flag++;
 }
 
+static void clean_snapshot(char *snapshot_dir) {
+	char subdir[8];
+	uint32_t i = 0;
+	struct stat st;
+
+	for (i = 0; i < 256; i++) {
+		sprintf(subdir, "%02x", i);
+		char *currentpath = string_build_path(snapshot_dir, subdir, NULL);
+
+		if ((stat(currentpath, &st) == 0) && S_ISDIR(st.st_mode)) {
+#ifdef WIN32
+			RemoveDirectory(currentpath);
+#else
+			remove(currentpath);
+#endif
+		}
+		free(currentpath);
+	}
+}
+
 static void print_usage(int argc, char **argv)
 {
 	char *name = NULL;
@@ -1951,6 +1971,10 @@ checkpoint:
 								}
 								char *newpath = string_build_path(backup_directory, str, NULL);
 								free(str);
+
+								if (strcmp(newpath, "Snapshot")) {
+									clean_snapshot(newpath);
+								}
 #ifdef WIN32
 								int res = 0;
 								if ((stat(newpath, &st) == 0) && S_ISDIR(st.st_mode))


### PR DESCRIPTION
I tried to backup iOS 10 device data by idevicebackup2 but failed. The reason is snapshot directory  has any empty directories in itself. Directory structure of snapshot fetched from iOS is changed from iOS10.

iOS9 or earlier: backup_dir/{UDID}/backup_files
iOS10: backup_dir/{UDID}/([0-9a-f]{2})/backup_files

This fix works for the same purpose as #342 but by another approach. It works to remove empty directory "00-ff" only in snapshot directory on iOS 10.
