### PR TITLE
Fix for connecting elder ios devices

### DIFF
--- a/include/libimobiledevice/lockdown.h
+++ b/include/libimobiledevice/lockdown.h
@@ -464,6 +464,17 @@ lockdownd_error_t lockdownd_data_classes_free(char **classes);
  */
 lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service);
 
+/**
+ * Returns the iOS version of the device from lockdownd.
+ *
+ * @param client An initialized lockdownd client.
+ * @param udid Holds the iOS version string of the device. The caller is responsible
+ *  for freeing the memory.
+ *
+ * @return LOCKDOWN_E_SUCCESS on success
+ */
+lockdownd_error_t lockdownd_get_device_version(lockdownd_client_t client, char **version);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -1522,3 +1522,19 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdow
 
 	return LOCKDOWN_E_SUCCESS;
 }
+
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_version(lockdownd_client_t client, char **version)
+{
+	lockdownd_error_t ret = LOCKDOWN_E_UNKNOWN_ERROR;
+	plist_t value = NULL;
+
+	ret = lockdownd_get_value(client, NULL, "ProductVersion", &value);
+	if (ret != LOCKDOWN_E_SUCCESS) {
+		return ret;
+	}
+	plist_get_string_val(value, udid);
+
+	plist_free(value);
+	value = NULL;
+	return ret;
+}

--- a/src/service.c
+++ b/src/service.c
@@ -178,7 +178,24 @@ LIBIMOBILEDEVICE_API service_error_t service_enable_ssl(service_client_t client)
 {
 	if (!client || !client->connection)
 		return SERVICE_E_INVALID_ARG;
-	return idevice_to_service_error(idevice_connection_enable_ssl(client->connection));
+
+	char * device_version = NULL;
+	BOOL sslv3 = FALSE;
+	if ((lockdownd_get_device_version(client->connection, device_version) == LOCKDOWN_E_SUCCESS) && device_version))
+	{
+		char * majorsplit = strchr(device_version, '.');
+		int len = majorsplit - deviceversion - 1;
+		char * versionmaj = (char *)malloc(len + 1);
+		strncpy(versionmaj, device_version, len);
+		versionmaj[len] = '\0';
+		int versionmajint = atoi(versionmaj);
+		if (versionmajint < 9)
+			sslv3 = TRUE;
+		free(device_version);
+		free(versionmaj);
+	}
+
+	return idevice_to_service_error(idevice_connection_enable_ssl(client->connection, sslv3));
 }
 
 LIBIMOBILEDEVICE_API service_error_t service_disable_ssl(service_client_t client)


### PR DESCRIPTION
iOS 5 and iOS 4 devices (tested) have problem with autonegotiation of SSL protocol version when enabling secure connection.

This will force using SSL3 on this devices (actually patch will force SSLv3 on all devices prior TLS1 support - eg. prior iOS 9).

Solution is suboptimal, since it queries iOS version every time you try to enable SSL, optimal will be, if iOS major number is stored in one of structures used, and queried only on device connect.

code is written to support compilation with openssl < 1.1, but also on openssl 1.1 with disabled deprecated apis