### PR TITLE
Fix UaF in deallocation of OpenSSL memory.

### DIFF
--- a/src/idevice.c
+++ b/src/idevice.c
@@ -98,9 +98,7 @@ static void internal_idevice_deinit(void)
 		mutex_buf = NULL;
 	}
 
-	EVP_cleanup();
-	CRYPTO_cleanup_all_ex_data();
-	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
+	SSL_COMP_free_compression_methods();
 #ifdef HAVE_ERR_REMOVE_THREAD_STATE
 	ERR_remove_thread_state(NULL);
 #else


### PR DESCRIPTION
Prior to change, running even noop commands would spit out a fairly large dump. Running it in valgrind gives this:

```
$ valgrind ideviceinstaller
==26890== Memcheck, a memory error detector
==26890== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==26890== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==26890== Command: ideviceinstaller
==26890==
ERROR: No mode/command was supplied.
Usage: ideviceinstaller OPTIONS
Manage apps on iOS devices.

  -u, --udid UDID	Target specific device by its 40-digit device UDID.
  -l, --list-apps	List apps, possible options:
       -o list_user	- list user apps only (this is the default)
       -o list_system	- list system apps only
       -o list_all	- list all types of apps
       -o xml		- print full output as xml plist
  -i, --install ARCHIVE	Install app from package file specified by ARCHIVE.
                       	ARCHIVE can also be a .ipcc file for carrier bundles.
  -U, --uninstall APPID	Uninstall app specified by APPID.
  -g, --upgrade ARCHIVE	Upgrade app from package file specified by ARCHIVE.
  -L, --list-archives	List archived applications, possible options:
       -o xml		- print full output as xml plist
  -a, --archive APPID	Archive app specified by APPID, possible options:
       -o uninstall	- uninstall the package after making an archive
       -o app_only	- archive application data only
       -o docs_only	- archive documents (user data) only
       -o copy=PATH	- copy the app archive to directory PATH when done
       -o remove	- only valid when copy=PATH is used: remove after copy
  -r, --restore APPID	Restore archived app specified by APPID
  -R, --remove-archive APPID  Remove app archive specified by APPID
  -o, --options		Pass additional options to the specified command.
  -h, --help		prints usage information
  -d, --debug		enable communication debugging

Homepage: <http://libimobiledevice.org>
==26890== Invalid read of size 4
==26890==    at 0x5E57799: OPENSSL_sk_pop_free (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C858: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5E01EF1: OPENSSL_cleanup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x56C7C8E: __cxa_finalize (cxa_finalize.c:56)
==26890==    by 0x5D19102: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Address 0x9893210 is 0 bytes inside a block of size 40 free'd
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x4E3F2D8: sk_SSL_COMP_free (ssl.h:822)
==26890==    by 0x4E3F2D8: internal_idevice_deinit (idevice.c:101)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Block was alloc'd at
==26890==    at 0x4C2ABAF: malloc (vg_replace_malloc.c:299)
==26890==    by 0x5E056DD: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5E5724E: OPENSSL_sk_new (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A59033: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5B036: SSL_COMP_get_compression_methods (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5A5C7EC: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C91A: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x4E3F26C: internal_idevice_init (idevice.c:73)
==26890==
==26890== Invalid read of size 8
==26890==    at 0x5E57519: OPENSSL_sk_free (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C858: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5E01EF1: OPENSSL_cleanup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x56C7C8E: __cxa_finalize (cxa_finalize.c:56)
==26890==    by 0x5D19102: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Address 0x9893218 is 8 bytes inside a block of size 40 free'd
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x4E3F2D8: sk_SSL_COMP_free (ssl.h:822)
==26890==    by 0x4E3F2D8: internal_idevice_deinit (idevice.c:101)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Block was alloc'd at
==26890==    at 0x4C2ABAF: malloc (vg_replace_malloc.c:299)
==26890==    by 0x5E056DD: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5E5724E: OPENSSL_sk_new (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A59033: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5B036: SSL_COMP_get_compression_methods (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5A5C7EC: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C91A: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x4E3F26C: internal_idevice_init (idevice.c:73)
==26890==
==26890== Invalid free() / delete / delete[] / realloc()
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x5E5752D: OPENSSL_sk_free (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C858: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5E01EF1: OPENSSL_cleanup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x56C7C8E: __cxa_finalize (cxa_finalize.c:56)
==26890==    by 0x5D19102: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Address 0x9893280 is 0 bytes inside a block of size 32 free'd
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x5E5752D: OPENSSL_sk_free (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x4E3F2D8: sk_SSL_COMP_free (ssl.h:822)
==26890==    by 0x4E3F2D8: internal_idevice_deinit (idevice.c:101)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Block was alloc'd at
==26890==    at 0x4C2ABAF: malloc (vg_replace_malloc.c:299)
==26890==    by 0x5E056DD: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5E5726C: OPENSSL_sk_new (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A59033: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5B036: SSL_COMP_get_compression_methods (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5A5C7EC: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C91A: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x4E3F26C: internal_idevice_init (idevice.c:73)
==26890==
==26890== Invalid free() / delete / delete[] / realloc()
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x5A5C858: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5E01EF1: OPENSSL_cleanup (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x56C7C8E: __cxa_finalize (cxa_finalize.c:56)
==26890==    by 0x5D19102: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Address 0x9893210 is 0 bytes inside a block of size 40 free'd
==26890==    at 0x4C2BDDB: free (vg_replace_malloc.c:530)
==26890==    by 0x4E3F2D8: sk_SSL_COMP_free (ssl.h:822)
==26890==    by 0x4E3F2D8: internal_idevice_deinit (idevice.c:101)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x400FBA9: _dl_fini (dl-fini.c:235)
==26890==    by 0x56C791F: __run_exit_handlers (exit.c:83)
==26890==    by 0x56C7979: exit (exit.c:105)
==26890==    by 0x10ADE5: parse_opts (ideviceinstaller.c:481)
==26890==    by 0x10ADE5: main (ideviceinstaller.c:657)
==26890==  Block was alloc'd at
==26890==    at 0x4C2ABAF: malloc (vg_replace_malloc.c:299)
==26890==    by 0x5E056DD: CRYPTO_zalloc (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5E5724E: OPENSSL_sk_new (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A59033: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5B036: SSL_COMP_get_compression_methods (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x5A5C7EC: ??? (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x6342778: __pthread_once_slow (pthread_once.c:116)
==26890==    by 0x5E57A68: CRYPTO_THREAD_run_once (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
==26890==    by 0x5A5C91A: OPENSSL_init_ssl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==26890==    by 0x4E3F26C: internal_idevice_init (idevice.c:73)
==26890==
==26890==
==26890== HEAP SUMMARY:
==26890==     in use at exit: 0 bytes in 0 blocks
==26890==   total heap usage: 668 allocs, 670 frees, 96,241 bytes allocated
==26890==
==26890== All heap blocks were freed -- no leaks are possible
==26890==
==26890== For counts of detected and suppressed errors, rerun with: -v
==26890== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

However, removing these functions did not fix the problem. Looking around some more, I stumbled across this function:

[SSL_COMP_free_compression_methods(void)](https://www.openssl.org/docs/man1.0.2/ssl/SSL_COMP_free_compression_methods.html)

Which seemed to do what the remaining deinit task was attempting. Swapping the functions out removed the UaF. After the change, valgrind runs cleanly.

All of this was tested on Debian sid amd64.