### PR TITLE
property_list_service: Remove packet length check when receiving plist data

### DIFF
--- a/src/property_list_service.c
+++ b/src/property_list_service.c
@@ -193,59 +193,56 @@ static property_list_service_error_t internal_plist_receive_timeout(property_lis
 		debug_info("initial read failed!");
 		return PROPERTY_LIST_SERVICE_E_MUX_ERROR;
 	} else {
-		pktlen = be32toh(pktlen);
-		if (pktlen < (1 << 24)) { /* prevent huge buffers */
-			uint32_t curlen = 0;
-			char *content = NULL;
-			debug_info("%d bytes following", pktlen);
-			content = (char*)malloc(pktlen);
-			if (!content) {
-				debug_info("out of memory when allocating %d bytes", pktlen);
-				return PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR;
-			}
+		uint32_t curlen = 0;
+		char *content = NULL;
 
-			while (curlen < pktlen) {
-				service_receive(client->parent, content+curlen, pktlen-curlen, &bytes);
-				if (bytes <= 0) {
-					res = PROPERTY_LIST_SERVICE_E_MUX_ERROR;
-					break;
-				}
-				debug_info("received %d bytes", bytes);
-				curlen += bytes;
+		pktlen = be32toh(pktlen);
+		debug_info("%d bytes following", pktlen);
+		content = (char*)malloc(pktlen);
+		if (!content) {
+			debug_info("out of memory when allocating %d bytes", pktlen);
+			return PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR;
+		}
+
+		while (curlen < pktlen) {
+			service_receive(client->parent, content+curlen, pktlen-curlen, &bytes);
+			if (bytes <= 0) {
+				res = PROPERTY_LIST_SERVICE_E_MUX_ERROR;
+				break;
 			}
-			if (curlen < pktlen) {
-				debug_info("received incomplete packet (%d of %d bytes)", curlen, pktlen);
-				if (curlen > 0) {
-					debug_info("incomplete packet following:");
-					debug_buffer(content, curlen);
-				}
-				free(content);
-				return res;
-			}
-			if ((pktlen > 8) && !memcmp(content, "bplist00", 8)) {
-				plist_from_bin(content, pktlen, plist);
-			} else if ((pktlen > 5) && !memcmp(content, "<?xml", 5)) {
-				/* iOS 4.3+ hack: plist data might contain invalid characters, thus we convert those to spaces */
-				for (bytes = 0; bytes < pktlen-1; bytes++) {
-					if ((content[bytes] >= 0) && (content[bytes] < 0x20) && (content[bytes] != 0x09) && (content[bytes] != 0x0a) && (content[bytes] != 0x0d))
-						content[bytes] = 0x20;
-				}
-				plist_from_xml(content, pktlen, plist);
-			} else {
-				debug_info("WARNING: received unexpected non-plist content");
-				debug_buffer(content, pktlen);
-			}
-			if (*plist) {
-				debug_plist(*plist);
-				res = PROPERTY_LIST_SERVICE_E_SUCCESS;
-			} else {
-				res = PROPERTY_LIST_SERVICE_E_PLIST_ERROR;
+			debug_info("received %d bytes", bytes);
+			curlen += bytes;
+		}
+		if (curlen < pktlen) {
+			debug_info("received incomplete packet (%d of %d bytes)", curlen, pktlen);
+			if (curlen > 0) {
+				debug_info("incomplete packet following:");
+				debug_buffer(content, curlen);
 			}
 			free(content);
-			content = NULL;
-		} else {
-			res = PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR;
+			return res;
 		}
+		if ((pktlen > 8) && !memcmp(content, "bplist00", 8)) {
+			plist_from_bin(content, pktlen, plist);
+		} else if ((pktlen > 5) && !memcmp(content, "<?xml", 5)) {
+			/* iOS 4.3+ hack: plist data might contain invalid characters, thus we convert those to spaces */
+			for (bytes = 0; bytes < pktlen-1; bytes++) {
+				if ((content[bytes] >= 0) && (content[bytes] < 0x20) && (content[bytes] != 0x09) && (content[bytes] != 0x0a) && (content[bytes] != 0x0d))
+					content[bytes] = 0x20;
+			}
+			plist_from_xml(content, pktlen, plist);
+		} else {
+			debug_info("WARNING: received unexpected non-plist content");
+			debug_buffer(content, pktlen);
+		}
+		if (*plist) {
+			debug_plist(*plist);
+			res = PROPERTY_LIST_SERVICE_E_SUCCESS;
+		} else {
+			res = PROPERTY_LIST_SERVICE_E_PLIST_ERROR;
+		}
+		free(content);
+		content = NULL;
 	}
 	return res;
 }


### PR DESCRIPTION
There are services that would send really large plist data, e.g. when listing provisioning profiles. Instead of forcing the data to be less than 16MB we try to allocate a buffer as large as requested. If the allocation fails the function returns with an error.