### PR TITLE
terminate QSetLogging command

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -341,7 +341,7 @@ int main(int argc, char *argv[])
 			/* enable logging for the session in debug mode */
 			if (debug_level) {
 				debug_info("Setting logging bitmask...");
-				debugserver_command_new("QSetLogging:bitmask=LOG_ALL|LOG_RNB_REMOTE|LOG_RNB_PACKETS", 0, NULL, &command);
+				debugserver_command_new("QSetLogging:bitmask=LOG_ALL|LOG_RNB_REMOTE|LOG_RNB_PACKETS;", 0, NULL, &command);
 				dres = debugserver_client_send_command(debugserver_client, command, &response);
 				debugserver_command_free(command);
 				command = NULL;


### PR DESCRIPTION
The `QSetLogging` command wasn't terminated with a `;`.  compare previous and new usage

previous syslog with `idevicedebug -d bundle_id`
```
 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: debugserver will use os_log for internal logging.
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: debugserver-@(#)PROGRAM:debugserver  PROJECT:debugserver-360.0.26.14
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: Connecting to com.apple.debugserver service...
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: Got a connection, waiting for process information for launching or attaching.
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: Sending AppProxy info: sequence no: 744, GUID: 9174F743-4EBC-401B-A6D2-01B26C629A30.
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Error>: error: Unrecognized event type: .  Ignoring.
Mar 25 15:36:27 shanes-iPad debugserver[1152] <Notice>: About to launch process for bundle ID: com.my.app
# ...
```

with fix
```
r 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: debugserver will use os_log for internal logging.
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: debugserver-@(#)PROGRAM:debugserver  PROJECT:debugserver-360.0.26.14
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: Connecting to com.apple.debugserver service...
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: Got a connection, waiting for process information for launching or attaching.
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 1 +0.000000 sec [053d/0303]:     8104 RNBRemote::SendPacket (OK) called
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 2 +0.000306 sec [053d/0303]: ::write ( socket = 5, buffer = 0x16dc4eeb0, length = 6) => 6 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 3 +0.000076 sec [053d/0303]: putpkt: $OK#9a
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 4 +0.000064 sec [053d/0303]: sent: $OK#9a
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 5 +0.000831 sec [053d/1607]: ::read ( 5, 0x16ddeea38, 1024 ) => 1 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 6 +0.000095 sec [053d/1607]: read: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 7 +0.000059 sec [053d/1607]: getpkt: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 8 +0.000098 sec [053d/0303]:     1538 RNBRemote::SendPacket ($OK#9a) got reply: '+'
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 9 +0.000003 sec [053d/1607]: ::read ( 5, 0x16ddeea38, 1024 ) => 30 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 10 +0.000081 sec [053d/0303]: #### RNBRunLoopGetStartModeFromRemote
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 11 +0.000091 sec [053d/1607]: read: $QSetMaxPacketSize:31303234#63
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 12 +0.000078 sec [053d/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) ...
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 13 +0.000074 sec [053d/1607]: getpkt: $QSetMaxPacketSize:31303234#63
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 14 +0.000154 sec [053d/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) => 0x00000020
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 15 +0.000084 sec [053d/0303]: ::write ( socket = 5, buffer = 0x10220e46c, length = 1) => 1 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 16 +0.000085 sec [053d/0303]: putpkt: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 17 +0.000063 sec [053d/0303]: sent: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 18 +0.000073 sec [053d/0303]: HandleReceivedPacket ("QSetMaxPacketSize:31303234");
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 19 +0.000135 sec [053d/0303]:      922 RNBRemote::SendPacket (OK) called
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 20 +0.000097 sec [053d/0303]: ::write ( socket = 5, buffer = 0x16dc4eea0, length = 6) => 6 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 21 +0.000212 sec [053d/0303]: putpkt: $OK#9a
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 22 +0.000064 sec [053d/0303]: sent: $OK#9a
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 23 +0.000459 sec [053d/1607]: ::read ( 5, 0x16ddeea38, 1024 ) => 1 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 24 +0.000115 sec [053d/1607]: read: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 25 +0.000077 sec [053d/1607]: getpkt: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 26 +0.000075 sec [053d/1607]: ::read ( 5, 0x16ddeea38, 1024 ) => 187 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 27 +0.000057 sec [053d/0303]:     1155 RNBRemote::SendPacket ($OK#9a) got reply: '+'
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 28 +0.000036 sec [053d/1607]: read: $QSetWorkingDir:2F707269766174652F7661722F6D6F62696C652F436F6E7461696E6572732F446174612F4170706C69636174696F6E2F39303541333043302D443635442
D343638312D423035422D413032353930413939323837#44
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 29 +0.000072 sec [053d/0303]: #### RNBRunLoopGetStartModeFromRemote
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 30 +0.000093 sec [053d/1607]: getpkt: $QSetWorkingDir:2F707269766174652F7661722F6D6F62696C652F436F6E7461696E6572732F446174612F4170706C69636174696F6E2F39303541333043302D4436354
42D343638312D423035422D413032353930413939323837#44
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 31 +0.000086 sec [053d/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) ...
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 32 +0.000372 sec [053d/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) => 0x00000020
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 33 +0.000236 sec [053d/0303]: ::write ( socket = 5, buffer = 0x10220e46c, length = 1) => 1 err = 0x00000000
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 34 +0.000058 sec [053d/0303]: putpkt: +
Mar 26 14:25:03 shanes-iPad debugserver[1341] <Notice>: 35 +0.000055 sec [053d/0303]: sent: +
# ...
```