### PR TITLE
Fix idevicedebug argv encoding

### DIFF
--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -216,6 +216,7 @@ static int debugserver_hex2int(char c)
 
 static char debugserver_int2hex(int x)
 {
+	x &= 0xf;
 	const char *hexchars = "0123456789ABCDEF";
 	return hexchars[x];
 }


### PR DESCRIPTION
The argv encoding for the "A" command in idevicedebug could have an issue when encoding a character of 0x80 or higher (e.g. some UTF-8 characters) which could lead to a crash in the on-device debugserver.  A simple fix to mask off the the high bits in debugserver_int2hex() addresses the issue.

Example of debugerver otuput without this fix.  Note the "ILLFORMED" line
```
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 45 +0.000038 sec [053f/0303]: #### RNBRunLoopGetStartModeFromRemote
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 46 +0.000044 sec [053f/1707]: getpkt: $A234,0,2F707269766174652F7661722F636F6E7461696E6572732F42756E646C652F4170706C69636174696F6E2F36393942344233432D363138412D343941412D393935362D4431363837453745454337442F5061726C6F6E73204265%C 16265%C 12E6170702F5061726
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 47 +0.000035 sec [053f/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) ...
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 48 +0.000096 sec [053f/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) => 0x00000020
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 49 +0.000079 sec [053f/0303]: ::write ( socket = 5, buffer = 0x10426646c, length = 1) => 1 err = 0x00000000
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 50 +0.000035 sec [053f/0303]: putpkt: +
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 51 +0.000090 sec [053f/0303]: sent: +
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 52 +0.000040 sec [053f/0303]: HandleReceivedPacket ("A234,0,2F707269766174652F7661722F636F6E7461696E6572732F42756E646C652F4170706C69636174696F6E2F36393942344233432D363138412D343941412D393935362D4431363837453745454337442F5061726C6F6E73204265%C 16265%C 12E6
Mar 26 14:50:10 shanes-iPad debugserver[1343] <Notice>: 53 +0.000219 sec [053f/0303]:      733 /BuildRoot/Library/Caches/com.apple.xbs/Sources/lldb/lldb-360.0.26.14/tools/debugserver/source/RNBRemote.cpp:1582 ILLFORMED: 'HandlePacket_ILLFORMED' (234,0,2F707269766174652F7661722F636F6E7461696E6572732F42756E646C6
```

Example with fix, process launches without issue.
```
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 44 +0.000090 sec [0543/0303]: #### RNBRunLoopGetStartModeFromRemote
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 45 +0.000203 sec [0543/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) ...
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 46 +0.000259 sec [0543/0303]: RNBRunLoopGetStartModeFromRemote ctx.Events().WaitForSetEvents( 0x000000a0 ) => 0x00000020
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 47 +0.000239 sec [0543/0303]: ::write ( socket = 5, buffer = 0x1003b246c, length = 1) => 1 err = 0x00000000
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 48 +0.000261 sec [0543/0303]: putpkt: +
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 49 +0.000258 sec [0543/0303]: sent: +
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 50 +0.000159 sec [0543/0303]: HandleReceivedPacket ("A234,0,2F707269766174652F7661722F636F6E7461696E6572732F42756E646C652F4170706C69636174696F6E2F36393942344233432D363138412D343941412D393935362D4431363837453745454337442F5061726C6F6E73204265CC816265CC812E6
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 51 +0.000312 sec [0543/0303]:     1782 RNBRemote::SendPacket (OK) called
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 52 +0.000117 sec [0543/0303]: ::write ( socket = 5, buffer = 0x16faaae70, length = 6) => 6 err = 0x00000000
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 53 +0.000146 sec [0543/0303]: putpkt: $OK#9a
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 54 +0.000104 sec [0543/0303]: sent: $OK#9a
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 55 +0.000197 sec [0543/2707]: ::read ( 5, 0x16fcd6a38, 1024 ) => 19 err = 0x00000000
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 56 +0.000091 sec [0543/2707]: read: +$qLaunchSuccess#A5
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 57 +0.000183 sec [0543/2707]: getpkt: +
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 58 +0.000059 sec [0543/2707]: getpkt: $qLaunchSuccess#A5
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 59 +0.000108 sec [0543/0303]:     1006 RNBRemote::SendPacket ($OK#9a) got reply: '+'
Mar 26 15:38:25 shanes-iPad debugserver[1347] <Notice>: 60 +0.000088 sec [0543/0303]: RNBRunLoopLaunchInferior Launching '/private/var/containers/Bundle/Application/699B4B3C-618A-49AA-9956-D1687E7EEC7D/Parlons Be\M-L\M^Abe\M-L\M^A.app/Parlons Be\M-L\M^Abe\M-L\M^A'...
```
