### PR TITLE
Update debug.c to consistently output to stderr

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -66,13 +66,10 @@ static void debug_print_line(const char *func, const char *file, int line, const
 	/* trim ending newlines */
 
 	/* print header */
-	printf ("%s: ", header);
+	fprintf(stderr, "%s: ", header);
 
 	/* print actual debug content */
-	printf ("%s\n", buffer);
-
-	/* flush this output, as we need to debug */
-	fflush (stdout);
+	fprintf(stderr, "%s\n", buffer);
 
 	free (header);
 }


### PR DESCRIPTION
This makes debug_print_line consistent with debug_buffer and among other things, ensures output from `idevicedebug run` can be easily divided into output from the app itself (stdout) from debug output from libimobiledevice (stderr).