### PR TITLE
tools,common: support any port in idevicedebugserverproxy

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -390,3 +390,24 @@ int socket_send(int fd, void *data, size_t length)
 {
 	return send(fd, data, length, 0);
 }
+
+int socket_get_socket_port(int fd, uint16_t *port)
+{
+#ifdef WIN32
+	int addr_len;
+#else
+	socklen_t addr_len;
+#endif
+	struct sockaddr_in addr;
+
+	memset(&addr, 0, sizeof(addr));
+
+	addr_len = sizeof(addr);
+	if (0 > getsockname(fd, (struct sockaddr*)&addr, &addr_len)) {
+		perror("getsockname()");
+		return -1;
+	}
+
+	*port = ntohs(addr.sin_port);
+	return 0;
+}

--- a/common/socket.h
+++ b/common/socket.h
@@ -62,4 +62,6 @@ int socket_send(int fd, void *data, size_t size);
 
 void socket_set_verbose(int level);
 
+int socket_get_socket_port(int fd, uint16_t *port);
+
 #endif	/* __SOCKET_SOCKET_H */


### PR DESCRIPTION
To eliminate crosstalk between multiple proxies and their clients,
add support for binding to any free port provided by the OS to
idevicedebugserverproxy. To bind to any port, leave out the port
argument to idevicedebugserverproxy. In that case, the proxy will
print out a line with the port so clients can connect to it.

This is useful for a CI macOS host with multiple iDevices
connected, and where many independent tests each want their own
proxy instance connected to a particular device.