### PR TITLE
Revise device udid validation to account for 2018 iPhones

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -30,7 +30,7 @@
 #include <sys/time.h>
 #include <inttypes.h>
 #include <ctype.h>
-
+#include <regex.h>
 #include "utils.h"
 
 #ifndef HAVE_STPCPY
@@ -479,5 +479,24 @@ void plist_print_to_stream(plist_t plist, FILE* stream)
 		break;
 	default:
 		plist_node_print_to_stream(plist, &indent, stream);
+	}
+}
+
+int is_udid_valid(char *udid)
+{
+	if (!udid) {
+		return 0;
+	}
+
+	regex_t regex;
+	regcomp(&regex, "^[[:xdigit:]-]{25,40}$", REG_EXTENDED);
+	int result = regexec(&regex, udid, 0, NULL, 0);
+	regfree(&regex);
+
+	if (result == 0) {
+		return 1;
+	}
+	else {
+		return 0;
 	}
 }

--- a/common/utils.h
+++ b/common/utils.h
@@ -56,5 +56,6 @@ int plist_read_from_filename(plist_t *plist, const char *filename);
 int plist_write_to_filename(plist_t plist, const char *filename, enum plist_format_t format);
 
 void plist_print_to_stream(plist_t plist, FILE* stream);
+int is_udid_valid(char *udid);
 
 #endif

--- a/docs/idevice_id.1
+++ b/docs/idevice_id.1
@@ -8,20 +8,20 @@ idevice_id \- Prints device name or a list of attached devices.
 .SH DESCRIPTION
 
 Prints device name or a list of attached devices.
-The UDID is a 40-digit hexadecimal number of the device
+The UDID is a 25 or 40 digit hexadecimal number of the device
 for which the name should be retrieved.
 
 .SH OPTIONS
 .TP
 .B \-l, \-\-list
 list UDID of all attached devices
-.TP 
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
-.TP 
+.TP
 
 .SH AUTHORS
  Zach C.

--- a/docs/idevicebackup.1
+++ b/docs/idevicebackup.1
@@ -12,11 +12,11 @@ Create or restore backup from the current or specified directory.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/docs/idevicebackup2.1
+++ b/docs/idevicebackup2.1
@@ -12,17 +12,17 @@ Create or restore backup from the current or specified directory.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-s, \-\-source UDID
 use backup data from device specified by UDID.
 .TP
 .B \-i, \-\-interactive
 request passwords interactively on the command line.
-.TP 
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/docs/idevicecrashreport.1
+++ b/docs/idevicecrashreport.1
@@ -25,7 +25,7 @@ copy but do not remove crash reports from device.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-h, \-\-help
 prints usage information.

--- a/docs/idevicedate.1
+++ b/docs/idevicedate.1
@@ -15,7 +15,7 @@ Simple utility to manage the clock on a device.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-s, \-\-set TIMESTAMP
 set UTC time described by TIMESTAMP

--- a/docs/idevicedebug.1
+++ b/docs/idevicedebug.1
@@ -12,16 +12,16 @@ command is "run" and allows execution of developer apps and watch the
 stdout/stderr of the process.
 
 .SH OPTIONS
-.TP 
+.TP
 .B \-e, \-\-env NAME=VALUE
 set environment variable NAME to VALUE.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/docs/idevicedebugserverproxy.1
+++ b/docs/idevicedebugserverproxy.1
@@ -17,11 +17,11 @@ The developer disk image needs to be mounted for this service to be available.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/docs/idevicediagnostics.1
+++ b/docs/idevicediagnostics.1
@@ -16,11 +16,11 @@ iOS 5 and later.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 
@@ -31,7 +31,7 @@ print diagnostics information from device optionally by TYPE. This includes
 "All", "WiFi", "GasGauge" or "NAND". Default is "All".
 .TP
 .B mobilegestalt KEY [...]
-print values of mobilegestalt keys passed as arguments after the command and 
+print values of mobilegestalt keys passed as arguments after the command and
 seperated by a space.
 .TP
 .B ioreg [PLANE]

--- a/docs/ideviceimagemounter.1
+++ b/docs/ideviceimagemounter.1
@@ -15,7 +15,7 @@ Mounts the specified disk image on the device.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-l, \-\-list
 list mount information

--- a/docs/ideviceinfo.1
+++ b/docs/ideviceinfo.1
@@ -15,7 +15,7 @@ Show information about the first connected device.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-q, \-\-domain NAME
 set domain of query to NAME. Default: None.

--- a/docs/idevicename.1
+++ b/docs/idevicename.1
@@ -21,7 +21,7 @@ is given the device name will be set to the name specified.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-h, \-\-help
 prints usage information

--- a/docs/idevicenotificationproxy.1
+++ b/docs/idevicenotificationproxy.1
@@ -12,7 +12,7 @@ Post or observe notifications on an iOS device from the command line.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-d, \-\-debug
 enable communication debugging.

--- a/docs/idevicepair.1
+++ b/docs/idevicepair.1
@@ -12,11 +12,11 @@ Manage host pairings with devices and usbmuxd.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/docs/ideviceprovision.1
+++ b/docs/ideviceprovision.1
@@ -12,14 +12,14 @@ Manage provisioning profiles on a device.
 .SH OPTIONS
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
-.TP 
+target specific device by its 25 or 40 digit device UDID.
+.TP
 .B \-x, \-\-xml
 print XML output when using the 'dump' command.
-.TP 
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
-.TP 
+.TP
 .B \-h, \-\-help
 prints usage information.
 
@@ -34,7 +34,7 @@ Get a list of all provisioning profiles on the device.
 .TP
 .B copy PATH
 Retrieves all provisioning profiles from the device and stores them into the
-existing directory specified by PATH. The files will be stored 
+existing directory specified by PATH. The files will be stored
 as "UUID.mobileprovision".
 .TP
 .B remove UUID

--- a/docs/idevicescreenshot.1
+++ b/docs/idevicescreenshot.1
@@ -22,7 +22,7 @@ the screenshotr service is not available.
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID.
+target specific device by its 25 or 40 digit device UDID.
 .TP
 .B \-h, \-\-help
 prints usage information

--- a/docs/idevicesyslog.1
+++ b/docs/idevicesyslog.1
@@ -10,13 +10,13 @@ idevicesyslog \- Relay syslog of a connected device.
 Relay syslog of a connected device.
 
 .SH OPTIONS
-.TP 
+.TP
 .B \-d, \-\-debug
 enable communication debugging.
 .TP
 .B \-u, \-\-udid UDID
-target specific device by its 40-digit device UDID
-.TP 
+target specific device by its 25 or 40 digit device UDID
+.TP
 .B \-h, \-\-help
 prints usage information.
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -2,90 +2,91 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)
 
 AM_CFLAGS = $(GLOBAL_CFLAGS) $(libgnutls_CFLAGS) $(libtasn1_CFLAGS) $(libgcrypt_CFLAGS) $(openssl_CFLAGS) $(libplist_CFLAGS) $(LFS_CFLAGS)
 AM_LDFLAGS = $(libgnutls_LIBS) $(libtasn1_LIBS) $(libgcrypt_LIBS) $(openssl_LIBS) $(libplist_LIBS)
+AM_LDADD = $(top_builddir)/common/libinternalcommon.la $(top_builddir)/src/libimobiledevice.la
 
 bin_PROGRAMS = idevice_id ideviceinfo idevicename idevicepair idevicesyslog ideviceimagemounter idevicescreenshot ideviceenterrecovery idevicedate idevicebackup idevicebackup2 ideviceprovision idevicedebugserverproxy idevicediagnostics idevicedebug idevicenotificationproxy idevicecrashreport
 
 ideviceinfo_SOURCES = ideviceinfo.c
 ideviceinfo_CFLAGS = $(AM_CFLAGS)
-ideviceinfo_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceinfo_LDADD = $(top_builddir)/src/libimobiledevice.la
+ideviceinfo_LDFLAGS = $(AM_LDFLAGS)
+ideviceinfo_LDADD = $(AM_LDADD)
 
 idevicename_SOURCES = idevicename.c
 idevicename_CFLAGS = $(AM_CFLAGS)
 idevicename_LDFLAGS = $(AM_LDFLAGS)
-idevicename_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicename_LDADD = $(AM_LDADD)
 
 idevicepair_SOURCES = idevicepair.c
 idevicepair_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicepair_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS) $(libusbmuxd_LIBS)
-idevicepair_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicepair_LDFLAGS = $(AM_LDFLAGS) $(libusbmuxd_LIBS)
+idevicepair_LDADD = $(AM_LDADD)
 
 idevicesyslog_SOURCES = idevicesyslog.c
 idevicesyslog_CFLAGS = $(AM_CFLAGS)
 idevicesyslog_LDFLAGS = $(AM_LDFLAGS)
-idevicesyslog_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicesyslog_LDADD = $(AM_LDADD)
 
 idevice_id_SOURCES = idevice_id.c
 idevice_id_CFLAGS = $(AM_CFLAGS)
 idevice_id_LDFLAGS = $(AM_LDFLAGS)
-idevice_id_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevice_id_LDADD = $(AM_LDADD)
 
 idevicebackup_SOURCES = idevicebackup.c
 idevicebackup_CFLAGS = $(AM_CFLAGS)
-idevicebackup_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicebackup_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicebackup_LDFLAGS = $(AM_LDFLAGS)
+idevicebackup_LDADD = $(AM_LDADD)
 
 idevicebackup2_SOURCES = idevicebackup2.c
 idevicebackup2_CFLAGS = $(AM_CFLAGS)
-idevicebackup2_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicebackup2_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicebackup2_LDFLAGS = $(AM_LDFLAGS)
+idevicebackup2_LDADD = $(AM_LDADD)
 
 ideviceimagemounter_SOURCES = ideviceimagemounter.c
 ideviceimagemounter_CFLAGS = $(AM_CFLAGS)
-ideviceimagemounter_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceimagemounter_LDADD = $(top_builddir)/src/libimobiledevice.la
+ideviceimagemounter_LDFLAGS = $(AM_LDFLAGS)
+ideviceimagemounter_LDADD = $(AM_LDADD)
 
 idevicescreenshot_SOURCES = idevicescreenshot.c
 idevicescreenshot_CFLAGS = $(AM_CFLAGS)
 idevicescreenshot_LDFLAGS = $(AM_LDFLAGS)
-idevicescreenshot_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicescreenshot_LDADD = $(AM_LDADD)
 
 ideviceenterrecovery_SOURCES = ideviceenterrecovery.c
 ideviceenterrecovery_CFLAGS = $(AM_CFLAGS)
 ideviceenterrecovery_LDFLAGS = $(AM_LDFLAGS)
-ideviceenterrecovery_LDADD = $(top_builddir)/src/libimobiledevice.la
+ideviceenterrecovery_LDADD = $(AM_LDADD)
 
 idevicedate_SOURCES = idevicedate.c
 idevicedate_CFLAGS = $(AM_CFLAGS)
 idevicedate_LDFLAGS = $(AM_LDFLAGS)
-idevicedate_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicedate_LDADD = $(AM_LDADD)
 
 ideviceprovision_SOURCES = ideviceprovision.c
 ideviceprovision_CFLAGS = $(AM_CFLAGS)
-ideviceprovision_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceprovision_LDADD = $(top_builddir)/src/libimobiledevice.la
+ideviceprovision_LDFLAGS = $(AM_LDFLAGS)
+ideviceprovision_LDADD = $(AM_LDADD)
 
 idevicedebugserverproxy_SOURCES = idevicedebugserverproxy.c
 idevicedebugserverproxy_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicedebugserverproxy_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicedebugserverproxy_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicedebugserverproxy_LDFLAGS = $(AM_LDFLAGS)
+idevicedebugserverproxy_LDADD = $(AM_LDADD)
 
 idevicediagnostics_SOURCES = idevicediagnostics.c
 idevicediagnostics_CFLAGS = $(AM_CFLAGS)
 idevicediagnostics_LDFLAGS = $(AM_LDFLAGS)
-idevicediagnostics_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicediagnostics_LDADD = $(AM_LDADD)
 
 idevicedebug_SOURCES = idevicedebug.c
 idevicedebug_CFLAGS = $(AM_CFLAGS)
-idevicedebug_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicedebug_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicedebug_LDFLAGS = $(AM_LDFLAGS)
+idevicedebug_LDADD = $(AM_LDADD)
 
 idevicenotificationproxy_SOURCES = idevicenotificationproxy.c
 idevicenotificationproxy_CFLAGS = $(AM_CFLAGS)
 idevicenotificationproxy_LDFLAGS = $(AM_LDFLAGS)
-idevicenotificationproxy_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicenotificationproxy_LDADD = $(AM_LDADD)
 
 idevicecrashreport_SOURCES = idevicecrashreport.c
 idevicecrashreport_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicecrashreport_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicecrashreport_LDADD = $(top_builddir)/src/libimobiledevice.la
+idevicecrashreport_LDFLAGS = $(AM_LDFLAGS)
+idevicecrashreport_LDADD = $(AM_LDADD)

--- a/tools/idevice_id.c
+++ b/tools/idevice_id.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
+#include "common/utils.h"
 
 #define MODE_NONE 0
 #define MODE_SHOW_ID 1
@@ -40,7 +41,7 @@ static void print_usage(int argc, char **argv)
 	name = strrchr(argv[0], '/');
 	printf("Usage: %s [OPTIONS] [UDID]\n", (name ? name + 1: argv[0]));
 	printf("Prints device name or a list of attached devices.\n\n");
-	printf("  The UDID is a 40-digit hexadecimal number of the device\n");
+	printf("  The UDID is a 25 or 40 digit hexadecimal number of the device\n");
 	printf("  for which the name should be retrieved.\n\n");
 	printf("  -l, --list\t\tlist UDID of all attached devices\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
@@ -79,7 +80,7 @@ int main(int argc, char **argv)
 	/* check if udid was passed */
 	if (mode == MODE_SHOW_ID) {
 		i--;
-		if (!argv[i] || (strlen(argv[i]) != 40)) {
+		if (!is_udid_valid(argv[i])) {
 			print_usage(argc, argv);
 			return 0;
 		}

--- a/tools/idevicebackup.c
+++ b/tools/idevicebackup.c
@@ -671,7 +671,7 @@ static void print_usage(int argc, char **argv)
 	printf("  restore\tRestores a device backup from DIRECTORY.\n\n");
 	printf("options:\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");
@@ -715,7 +715,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -1323,7 +1323,7 @@ static void print_usage(int argc, char **argv)
 	printf("\n");
 	printf("options:\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -s, --source UDID\tuse backup data from device specified by UDID\n");
 	printf("  -i, --interactive\trequest passwords interactively\n");
 	printf("  -h, --help\t\tprints usage information\n");
@@ -1369,7 +1369,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return -1;
 			}
@@ -1378,7 +1378,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-s") || !strcmp(argv[i], "--source")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return -1;
 			}

--- a/tools/idevicecrashreport.c
+++ b/tools/idevicecrashreport.c
@@ -301,7 +301,7 @@ static void print_usage(int argc, char **argv)
 	printf("  -e, --extract\t\textract raw crash report into separate '.crash' file\n");
 	printf("  -k, --keep\t\tcopy but do not remove crash reports from device\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");
@@ -327,7 +327,7 @@ int main(int argc, char* argv[]) {
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicedate.c
+++ b/tools/idevicedate.c
@@ -33,6 +33,7 @@
 
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
+#include "common/utils.h"
 
 #ifdef _DATE_FMT
 #define DATE_FMT_LANGINFO() nl_langinfo (_DATE_FMT)
@@ -50,7 +51,7 @@ static void print_usage(int argc, char **argv)
 	printf("NOTE: Setting the time on iOS 6 and later is only supported\n");
 	printf("      in the setup wizard screens before device activation.\n\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -s, --set TIMESTAMP\tset UTC time described by TIMESTAMP\n");
 	printf("  -c, --sync\t\tset time of device to current system time\n");
 	printf("  -h, --help\t\tprints usage information\n");
@@ -84,7 +85,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -41,6 +41,7 @@
 #include <libimobiledevice/debugserver.h>
 #include <plist/plist.h>
 #include "common/debug.h"
+#include "common/utils.h"
 
 enum cmd_mode {
 	CMD_NONE = 0,
@@ -188,7 +189,7 @@ static void print_usage(int argc, char **argv)
 	printf("\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
@@ -233,7 +234,7 @@ int main(int argc, char *argv[])
 			continue;
 		} else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				res = 0;
 				goto cleanup;

--- a/tools/idevicedebugserverproxy.c
+++ b/tools/idevicedebugserverproxy.c
@@ -34,6 +34,7 @@
 
 #include "common/socket.h"
 #include "common/thread.h"
+#include "common/utils.h"
 
 #define info(...) fprintf(stdout, __VA_ARGS__); fflush(stdout)
 #define debug(...) if(debug_mode) fprintf(stdout, __VA_ARGS__)
@@ -71,7 +72,7 @@ static void print_usage(int argc, char **argv)
 	printf("Usage: %s [OPTIONS] <PORT>\n", (name ? name + 1: argv[0]));
 	printf("Proxy debugserver connection from device to a local socket at PORT.\n\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");
@@ -280,7 +281,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicediagnostics.c
+++ b/tools/idevicediagnostics.c
@@ -32,6 +32,7 @@
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
 #include <libimobiledevice/diagnostics_relay.h>
+#include "common/utils.h"
 
 enum cmd_mode {
 	CMD_NONE = 0,
@@ -79,7 +80,7 @@ int main(int argc, char **argv)
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				result = 0;
 				goto cleanup;
@@ -318,7 +319,7 @@ void print_usage(int argc, char **argv)
 	printf("  sleep\t\t\t\tput device into sleep mode (disconnects from host)\n\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");

--- a/tools/ideviceenterrecovery.c
+++ b/tools/ideviceenterrecovery.c
@@ -30,6 +30,7 @@
 
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
+#include "common/utils.h"
 
 static void print_usage(int argc, char **argv)
 {
@@ -66,7 +67,7 @@ int main(int argc, char *argv[])
 	}
 
 	i--;
-	if (!argv[i] || (strlen(argv[i]) != 40)) {
+	if (!is_udid_valid(argv[i])) {
 		print_usage(argc, argv);
 		return 0;
 	}

--- a/tools/ideviceimagemounter.c
+++ b/tools/ideviceimagemounter.c
@@ -63,7 +63,7 @@ static void print_usage(int argc, char **argv)
 	name = strrchr(argv[0], '/');
 	printf("Usage: %s [OPTIONS] IMAGE_FILE IMAGE_SIGNATURE_FILE\n\n", (name ? name + 1: argv[0]));
 	printf("Mounts the specified disk image on the device.\n\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -l, --list\t\tList mount information\n");
 	printf("  -t, --imagetype\tImage type to use, default is 'Developer'\n");
 	printf("  -x, --xml\t\tUse XML output\n");

--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -91,7 +91,7 @@ static void print_usage(int argc, char **argv)
 	printf("Show information about a connected device.\n\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
 	printf("  -s, --simple\t\tuse a simple connection to avoid auto-pairing with the device\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -q, --domain NAME\tset domain of query to NAME. Default: None\n");
 	printf("  -k, --key NAME\tonly query key specified by NAME. Default: All keys.\n");
 	printf("  -x, --xml\t\toutput information as xml plist instead of key/value pairs\n");
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicenotificationproxy.c
+++ b/tools/idevicenotificationproxy.c
@@ -39,6 +39,7 @@
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
 #include <libimobiledevice/notification_proxy.h>
+#include "common/utils.h"
 
 enum cmd_mode {
 	CMD_NONE = 0,
@@ -70,7 +71,7 @@ static void print_usage(int argc, char **argv)
 	printf("\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");
@@ -114,7 +115,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				result = 0;
 				goto cleanup;

--- a/tools/idevicepair.c
+++ b/tools/idevicepair.c
@@ -72,7 +72,7 @@ static void print_usage(int argc, char **argv)
 	printf("  list         list devices paired with this host\n\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -d, --debug      enable communication debugging\n");
-	printf("  -u, --udid UDID  target specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID  target specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help       prints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");

--- a/tools/ideviceprovision.c
+++ b/tools/ideviceprovision.c
@@ -64,7 +64,7 @@ static void print_usage(int argc, char **argv)
 	printf("           \tspecified by FILE.\n\n");
 	printf(" The following OPTIONS are accepted:\n");
 	printf("  -d, --debug      enable communication debugging\n");
-	printf("  -u, --udid UDID  target specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID  target specific device by its 25 or 40 digit device UDID\n");
 	printf("  -x, --xml        print XML output when using the 'dump' command\n");
 	printf("  -h, --help       prints usage information\n");
 	printf("\n");
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}

--- a/tools/idevicescreenshot.c
+++ b/tools/idevicescreenshot.c
@@ -32,6 +32,7 @@
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
 #include <libimobiledevice/screenshotr.h>
+#include "common/utils.h"
 
 void print_usage(int argc, char **argv);
 
@@ -55,7 +56,7 @@ int main(int argc, char **argv)
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}
@@ -158,7 +159,7 @@ void print_usage(int argc, char **argv)
 	printf("NOTE: A mounted developer disk image is required on the device, otherwise\n");
 	printf("the screenshotr service is not available.\n\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");

--- a/tools/idevicesyslog.c
+++ b/tools/idevicesyslog.c
@@ -29,6 +29,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include "common/utils.h"
 
 #ifdef WIN32
 #include <windows.h>
@@ -185,7 +186,7 @@ int main(int argc, char *argv[])
 		}
 		else if (!strcmp(argv[i], "-u") || !strcmp(argv[i], "--udid")) {
 			i++;
-			if (!argv[i] || (strlen(argv[i]) != 40)) {
+			if (!is_udid_valid(argv[i])) {
 				print_usage(argc, argv);
 				return 0;
 			}
@@ -238,7 +239,7 @@ void print_usage(int argc, char **argv)
 	printf("Usage: %s [OPTIONS]\n", (name ? name + 1: argv[0]));
 	printf("Relay syslog of a connected device.\n\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
-	printf("  -u, --udid UDID\ttarget specific device by its 40-digit device UDID\n");
+	printf("  -u, --udid UDID\ttarget specific device by its 25 or 40 digit device UDID\n");
 	printf("  -h, --help\t\tprints usage information\n");
 	printf("\n");
 	printf("Homepage: <" PACKAGE_URL ">\n");


### PR DESCRIPTION
Newer iPhones no longer use the 40-digit hex UDID scheme, instead they use a 25-digit scheme that includes hyphens. Instead of only checking length of provided UDID, check it against a regex that allows for any 25 or 40 digit hex (with hyphens).

Added the new UDID validation function to common utils since it could be useful elsewhere.

This fixes #701 and #702