### PR TITLE
Support WiFi devices in idevice_new

### DIFF
--- a/src/idevice.c
+++ b/src/idevice.c
@@ -250,7 +250,7 @@ LIBIMOBILEDEVICE_API void idevice_set_debug_level(int level)
 LIBIMOBILEDEVICE_API idevice_error_t idevice_new(idevice_t * device, const char *udid)
 {
 	usbmuxd_device_info_t muxdev;
-	int res = usbmuxd_get_device_by_udid(udid, &muxdev);
+	int res = usbmuxd_get_device(udid, &muxdev, DEVICE_LOOKUP_USBMUX | DEVICE_LOOKUP_NETWORK);
 	if (res > 0) {
 		idevice_t dev = (idevice_t) malloc(sizeof(struct idevice_private));
 		dev->udid = strdup(muxdev.udid);


### PR DESCRIPTION
As a side-effect of the changes in libusbmuxd which bring better support for USB and WiFi connections, `usbmuxd_get_device_by_udid` only returns USB-connected devices.

Because `idevice_new` called into `usbmuxd_get_device_by_udid`, you would now get a scenario where `idevice_list` returns USB and WiFi-connected devices, but `idevice_new` would return E_NO_DEVICE when connecting to a device which is connect over WiFi only.

This PR changes the call from `usbmuxd_get_device_by_udid` to `usbmuxd_get_device` with ` DEVICE_LOOKUP_USBMUX | DEVICE_LOOKUP_NETWORK` so that USB connections are preferred, but a fallback to WiFi connections is possible.