### PR TITLE
configure.ac: Remove largefile hackery

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,30 +181,6 @@ esac
 
 # check for large file support
 AC_SYS_LARGEFILE
-LFS_CFLAGS=''
-if test "$enable_largefile" != no; then
-    if test "$ac_cv_sys_file_offset_bits" != 'no'; then
-	LFS_CFLAGS="$LFS_CFLAGS -D_FILE_OFFSET_BITS=$ac_cv_sys_file_offset_bits"
-    else
-	AC_MSG_CHECKING(for native large file support)
-	AC_RUN_IFELSE([AC_LANG_SOURCE([#include <unistd.h>
-	  int main (int argc, char **argv)
-	  {
-	      exit(!(sizeof(off_t) == 8));
-	  }])],
-	[ac_cv_sys_file_offset_bits=64; AC_DEFINE(_FILE_OFFSET_BITS,64)
-	 AC_MSG_RESULT(yes)],
-	[AC_MSG_RESULT(no)])
-    fi
-    if test "$ac_cv_sys_large_files" != 'no'; then
-	LFS_CFLAGS="$LFS_CFLAGS -D_LARGE_FILES=1"
-    fi
-    AC_FUNC_FSEEKO
-    if test "$ac_cv_sys_largefile_source" != 'no'; then
-	LFS_CFLAGS="$LFS_CFLAGS -D_LARGEFILE_SOURCE=1"
-    fi
-fi
-AC_SUBST(LFS_CFLAGS)
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
It requires a program to be ran, which cannot be done when cross compiling.
AC_SYS_LARGEFILE seems to be enough to implement largefile checking.