### PR TITLE
fix idevice installer hang

### DIFF
--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -367,17 +367,14 @@ static instproxy_error_t instproxy_receive_status_loop(instproxy_client_t client
 			/* check status from response */
 			instproxy_status_get_name(node, &status_name);
 			if (!status_name) {
-				debug_info("failed to retrieve name from status response with error %d.", res);
-				complete = 1;
-			}
-
-			if (status_name) {
+				debug_info("ignoring message without Status key:");
+				debug_plist(node);
+			} else {
 				if (!strcmp(status_name, "Complete")) {
 					complete = 1;
 				} else {
 					res = INSTPROXY_E_OP_IN_PROGRESS;
 				}
-
 #ifndef STRIP_DEBUG_CODE
 				percent_complete = -1;
 				instproxy_status_get_percent_complete(node, &percent_complete);


### PR DESCRIPTION
ideviceinstaller will hang unless it gets a completed message.

Some ios versions will interleave a CFBundleIdentifier message into the Status messages like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
 <key>PercentComplete</key>
 <integer>90</integer>
 <key>Status</key>
 <string>GeneratingApplicationMap</string>
</dict>
</plist>

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
 <key>CFBundleIdentifier</key>
 <string>com.whatweverapp.you.are.installing</string>
</dict>
</plist>

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
 <key>Status</key>
 <string>Complete</string>
</dict> 
```
The old code would treat the CFBundleIdentifier message as an error. terminating the loop, never seeing the last message and even worse never callback to ideviceinstaller that would be stuck waiting for a callback with a message where Status == Complete.