### PR TITLE
ideviceimagemounter: fix crash in connection teardown

### DIFF
--- a/tools/ideviceimagemounter.c
+++ b/tools/ideviceimagemounter.c
@@ -154,8 +154,10 @@ int main(int argc, char **argv)
 	size_t image_size = 0;
 	char *image_sig_path = NULL;
 
+#ifndef WIN32
 	/* Connection shutdown may cause SIGPIPE */
 	signal(SIGPIPE, SIG_IGN);
+#endif
 
 	parse_opts(argc, argv);
 

--- a/tools/ideviceimagemounter.c
+++ b/tools/ideviceimagemounter.c
@@ -34,6 +34,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <inttypes.h>
+#include <signal.h>
 
 #include <libimobiledevice/libimobiledevice.h>
 #include <libimobiledevice/lockdown.h>
@@ -152,6 +153,9 @@ int main(int argc, char **argv)
 	char *image_path = NULL;
 	size_t image_size = 0;
 	char *image_sig_path = NULL;
+
+	/* Connection shutdown may cause SIGPIPE */
+	signal(SIGPIPE, SIG_IGN);
 
 	parse_opts(argc, argv);
 
@@ -434,6 +438,10 @@ int main(int argc, char **argv)
 	if (result) {
 		plist_free(result);
 	}
+
+	/* Ensure we have output even if we crash in teardown */
+	fflush(stdout);
+	fflush(stderr);
 
 	/* perform hangup command */
 	mobile_image_mounter_hangup(mim);


### PR DESCRIPTION
We observed that ideviceimagemounter was consistently exiting with code 141 (tested ios9 and 13GM) and furthermore had no output when stdout was piped to a file.

Chased it down to the bug #50 issue. I tried all sorts of defensive measures in idevice_connection_disable_ssl(), but nothing worked. Ignoring SIGPIPE seems a bit like a band aid, but I can see that all other libimobile tools have it, so I guess it's ok :-)