### PR TITLE
debugserver: proxies SERVICE_E_TIMEOUT into DEBUGSERVER_E_TIMEOUT

### DIFF
--- a/include/libimobiledevice/debugserver.h
+++ b/include/libimobiledevice/debugserver.h
@@ -39,6 +39,7 @@ typedef enum {
 	DEBUGSERVER_E_MUX_ERROR      = -2,
 	DEBUGSERVER_E_SSL_ERROR      = -3,
 	DEBUGSERVER_E_RESPONSE_ERROR = -4,
+	DEBUGSERVER_E_TIMEOUT        = -5,
 	DEBUGSERVER_E_UNKNOWN_ERROR  = -256
 } debugserver_error_t;
 

--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -54,6 +54,8 @@ static debugserver_error_t debugserver_error(service_error_t err)
 			return DEBUGSERVER_E_MUX_ERROR;
 		case SERVICE_E_SSL_ERROR:
 			return DEBUGSERVER_E_SSL_ERROR;
+        case SERVICE_E_TIMEOUT:
+			return DEBUGSERVER_E_TIMEOUT;
 		default:
 			break;
 	}


### PR DESCRIPTION
this error is missing but required to properly handle timeout case in debugserver_client_receive_with_timeout