### PR TITLE
tools: Fix for ideviceinfo - invalid option -- s

### DIFF
--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
 	signal(SIGPIPE, SIG_IGN);
 #endif
 
-	while ((c = getopt_long(argc, argv, "dhu:nq:k:x", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "dhu:nq:k:x:s", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'd':
 			idevice_set_debug_level(1);


### PR DESCRIPTION
This PR fix ideviceinfo when it is used with '-s' parameter.