### PR TITLE
idevicedebug lacks proper error handling

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -352,6 +352,8 @@ int main(int argc, char *argv[])
 					}
 					free(response);
 					response = NULL;
+				} else {
+					goto cleanup;
 				}
 			}
 
@@ -370,6 +372,8 @@ int main(int argc, char *argv[])
 				}
 				free(response);
 				response = NULL;
+			} else {
+				goto cleanup;
 			}
 
 			/* set working directory */
@@ -386,6 +390,8 @@ int main(int argc, char *argv[])
 				}
 				free(response);
 				response = NULL;
+			} else {
+				goto cleanup;
 			}
 
 			/* set environment */
@@ -427,6 +433,8 @@ int main(int argc, char *argv[])
 				}
 				free(response);
 				response = NULL;
+			} else {
+				goto cleanup;
 			}
 
 			/* set thread */
@@ -442,6 +450,8 @@ int main(int argc, char *argv[])
 				}
 				free(response);
 				response = NULL;
+			} else {
+				goto cleanup;
 			}
 
 			/* continue running process */
@@ -450,6 +460,10 @@ int main(int argc, char *argv[])
 			dres = debugserver_client_send_command(debugserver_client, command, &response, NULL);
 			debugserver_command_free(command);
 			command = NULL;
+
+			if (!response) {
+				goto cleanup;
+			}
 
 			/* main loop which is parsing/handling packets during the run */
 			debug_info("Entering run loop...");


### PR DESCRIPTION
The code of idevicedebug completely ignores that the device may fail to send a response within the configured time out.

idevicedebug ignores this situation which often works well but in other situations it leads to the problem that the app can't be started on the device but idevicedebug continues as if the app would run.
Therefore idevicedebug continues to run (unless the user manually kills the idevicedebug process).

For making idevicedebug working reliable this PR add proper error handling for all responses in the set-up phase.

Note: I strongly recommend also to increase the default time-out of 1000 milliseconds as it is a bit low from my experience. In my opinion idevicedebug should provide a parameter to set the time-out instead of having a built-in unchangeable value.