### PR TITLE
Fix two small typos

### DIFF
--- a/cython/mobilesync.pxi
+++ b/cython/mobilesync.pxi
@@ -62,7 +62,7 @@ cdef class MobileSyncError(BaseError):
             MOBILESYNC_E_INVALID_ARG: "Invalid argument",
             MOBILESYNC_E_PLIST_ERROR: "Property list error",
             MOBILESYNC_E_MUX_ERROR: "MUX error",
-            MOBILESYNC_E_SSL_ERROR: "SSL eror",
+            MOBILESYNC_E_SSL_ERROR: "SSL error",
             MOBILESYNC_E_RECEIVE_TIMEOUT: "Receive timeout",
             MOBILESYNC_E_BAD_VERSION: "Bad version",
             MOBILESYNC_E_SYNC_REFUSED: "Sync refused",

--- a/docs/idevicesyslog.1
+++ b/docs/idevicesyslog.1
@@ -66,7 +66,7 @@ PROCESS is a string that can either be a numeric pid or a process name. It also 
 .B \-q, \-\-quiet
 set a filter to exclude common noisy processes
 
-Since the syslog can be quite noisy, this quick command line switch allows to silence out a predefined set of commonly known processes. The list of processes that are silenced can be retrieved with \f[B]\-\-quiet\-list\f[].
+Since the syslog can be quite noisy, this quick command line switch allows one to silence out a predefined set of commonly known processes. The list of processes that are silenced can be retrieved with \f[B]\-\-quiet\-list\f[].
 .TP
 .B \-\-quiet\-list
 prints the list of processes for \f[B]\-\-quiet\f[] and exits


### PR DESCRIPTION
One typo in Cython error strings and one in idevicesyslog manpage