### PR TITLE
Fixed: Mistreatment of 0-byte sent cases

### DIFF
--- a/src/idevice.c
+++ b/src/idevice.c
@@ -599,7 +599,10 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_send(idevice_connection_
 		}
 		debug_info("internal_connection_send %d, sent %d", len, sent);
 		if (sent < len) {
-			*sent_bytes = 0;
+			*sent_bytes = sent;
+			if (sent == 0) {
+				return IDEVICE_E_UNKNOWN_ERROR;
+			}
 			return IDEVICE_E_NOT_ENOUGH_DATA;
 		}
 		*sent_bytes = sent;


### PR DESCRIPTION
Currently if 0 byte gets sent, it is treated as not-enough-data. 
This is wrong, because with TCP, 0-byte-sent usually means the receiver end is closed. We must set a new case for this and must not normalize the sent-bytes to 0 in general.