### PR TITLE
idevicedebug: allow to start an app and exit idevicedebug without killing the started app

### DIFF
--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -197,7 +197,7 @@ static void print_usage(int argc, char **argv)
 	printf("The following OPTIONS are accepted:\n");
 	printf("  -u, --udid UDID\ttarget specific device by UDID\n");
 	printf("  -n, --network\t\tconnect to network device\n");
-	printf("      --disconnect\tOnce the app is running disconnect andlet the app alive.\n");
+	printf("      --disconnect\tOnce the app is running, disconnect and let the app live\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
 	printf("  -h, --help\t\tprints usage information\n");

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -197,6 +197,7 @@ static void print_usage(int argc, char **argv)
 	printf("The following OPTIONS are accepted:\n");
 	printf("  -u, --udid UDID\ttarget specific device by UDID\n");
 	printf("  -n, --network\t\tconnect to network device\n");
+	printf("      --disconnect\tOnce the app is running disconnect andlet the app alive.\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
 	printf("  -h, --help\t\tprints usage information\n");
@@ -217,6 +218,7 @@ int main(int argc, char *argv[])
 	int cmd = CMD_NONE;
 	const char* udid = NULL;
 	int use_network = 0;
+	int disconnect_after_start = 0;
 	const char* bundle_identifier = NULL;
 	char* path = NULL;
 	char* working_directory = NULL;
@@ -253,6 +255,9 @@ int main(int argc, char *argv[])
 			continue;
 		} else if (!strcmp(argv[i], "-n") || !strcmp(argv[i], "--network")) {
 			use_network = 1;
+			continue;
+		} else if (!strcmp(argv[i], "--disconnect")) {
+			disconnect_after_start = 1;
 			continue;
 		} else if (!strcmp(argv[i], "-e") || !strcmp(argv[i], "--env")) {
 			i++;
@@ -445,6 +450,17 @@ int main(int argc, char *argv[])
 				}
 				free(response);
 				response = NULL;
+			}
+
+			if (disconnect_after_start) {
+				log_debug("Disconnecting from app");
+				debugserver_command_new("D", 0, NULL, &command);
+				dres = debugserver_client_send_command(debugserver_client, command, &response, NULL);
+				debugserver_command_free(command);
+				command = NULL;
+
+				res = (dres == DEBUGSERVER_E_SUCCESS) ? 0: -1;
+				break;
 			}
 
 			/* set thread */

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -197,7 +197,7 @@ static void print_usage(int argc, char **argv)
 	printf("The following OPTIONS are accepted:\n");
 	printf("  -u, --udid UDID\ttarget specific device by UDID\n");
 	printf("  -n, --network\t\tconnect to network device\n");
-	printf("      --disconnect\tOnce the app is running, disconnect and let the app live\n");
+	printf("      --detach\t\tdetach from app after launch, keeping it running\n");
 	printf("  -e, --env NAME=VALUE\tset environment variable NAME to VALUE\n");
 	printf("  -d, --debug\t\tenable communication debugging\n");
 	printf("  -h, --help\t\tprints usage information\n");
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
 	int cmd = CMD_NONE;
 	const char* udid = NULL;
 	int use_network = 0;
-	int disconnect_after_start = 0;
+	int detach_after_start = 0;
 	const char* bundle_identifier = NULL;
 	char* path = NULL;
 	char* working_directory = NULL;
@@ -256,8 +256,8 @@ int main(int argc, char *argv[])
 		} else if (!strcmp(argv[i], "-n") || !strcmp(argv[i], "--network")) {
 			use_network = 1;
 			continue;
-		} else if (!strcmp(argv[i], "--disconnect")) {
-			disconnect_after_start = 1;
+		} else if (!strcmp(argv[i], "--detach")) {
+			detach_after_start = 1;
 			continue;
 		} else if (!strcmp(argv[i], "-e") || !strcmp(argv[i], "--env")) {
 			i++;
@@ -452,8 +452,8 @@ int main(int argc, char *argv[])
 				response = NULL;
 			}
 
-			if (disconnect_after_start) {
-				log_debug("Disconnecting from app");
+			if (detach_after_start) {
+				log_debug("Detaching from app");
 				debugserver_command_new("D", 0, NULL, &command);
 				dres = debugserver_client_send_command(debugserver_client, command, &response, NULL);
 				debugserver_command_free(command);


### PR DESCRIPTION
I often have the use case where I want to start an app on the iPhone and then disconnect the debugger from that app. 

As idevicedebug by default kills the started app when it ends (a feature that was not working correctly for a long time) I added a new command-line option `--disconnect` that starts an app disconnects the debugger and ends idevicedebug. In this case the app will continue to run.