### PR TITLE
Fix idevicescreenshot build on Ubuntu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,9 @@ if test "x$ac_cv_have_endian_h" = "xno"; then
   fi
 fi
 
+# idevicescreenshot uses floor
+AC_CHECK_LIB([m],[floor])
+
 # Check for operating system
 AC_MSG_CHECKING([for platform-specific build settings])
 case ${host_os} in

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -80,7 +80,7 @@ ideviceimagemounter_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicescreenshot_SOURCES = idevicescreenshot.c
 idevicescreenshot_CFLAGS = $(AM_CFLAGS)
-idevicescreenshot_LDFLAGS = $(AM_LDFLAGS)
+idevicescreenshot_LDFLAGS = $(AM_LDFLAGS) -lm
 idevicescreenshot_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 ideviceenterrecovery_SOURCES = ideviceenterrecovery.c


### PR DESCRIPTION
be72ca64cd9e853588ec65047d16a0a22f4ef291 added calls to `floor` and `log` which are defined in `libm`.

Check for this function and link `idevicescreenshot` with `libm`.

Fixes the build on Ubuntu.