### PR TITLE
clang-tidy: fix inconsistent declarations

### DIFF
--- a/common/socket.h
+++ b/common/socket.h
@@ -54,12 +54,12 @@ int socket_accept(int fd, uint16_t port);
 int socket_shutdown(int fd, int how);
 int socket_close(int fd);
 
-int socket_receive(int fd, void *data, size_t size);
-int socket_peek(int fd, void *data, size_t size);
-int socket_receive_timeout(int fd, void *data, size_t size, int flags,
+int socket_receive(int fd, void *data, size_t length);
+int socket_peek(int fd, void *data, size_t length);
+int socket_receive_timeout(int fd, void *data, size_t length, int flags,
 					 unsigned int timeout);
 
-int socket_send(int fd, void *data, size_t size);
+int socket_send(int fd, void *data, size_t length);
 
 void socket_set_verbose(int level);
 

--- a/include/libimobiledevice/installation_proxy.h
+++ b/include/libimobiledevice/installation_proxy.h
@@ -495,7 +495,7 @@ void instproxy_client_options_free(plist_t client_options);
  *         the path could not be determined or an INSTPROXY_E_* error
  *         value if an error occurred.
  */
-instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* bundle_id, char** path);
+instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* appid, char** path);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/notification_proxy.h
+++ b/include/libimobiledevice/notification_proxy.h
@@ -187,7 +187,7 @@ np_error_t np_observe_notifications(np_client_t client, const char **notificatio
  *         NP_E_INVALID_ARG when client is NULL, or NP_E_UNKNOWN_ERROR when
  *         the callback thread could no be created.
  */
-np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *userdata);
+np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *user_data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>