### PR TITLE
clang-tidy: use uppercase numeric literals

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -191,16 +191,16 @@ char *string_format_size(uint64_t size)
 	char buf[80];
 	double sz;
 	if (size >= 1000000000000LL) {
-		sz = ((double)size / 1000000000000.0f);
+		sz = ((double)size / 1000000000000.0F);
 		sprintf(buf, "%0.1f TB", sz);
 	} else if (size >= 1000000000LL) {
-		sz = ((double)size / 1000000000.0f);
+		sz = ((double)size / 1000000000.0F);
 		sprintf(buf, "%0.1f GB", sz);
 	} else if (size >= 1000000LL) {
-		sz = ((double)size / 1000000.0f);
+		sz = ((double)size / 1000000.0F);
 		sprintf(buf, "%0.1f MB", sz);
 	} else if (size >= 1000LL) {
-		sz = ((double)size / 1000.0f);
+		sz = ((double)size / 1000.0F);
 		sprintf(buf, "%0.1f KB", sz);
 	} else {
 		sprintf(buf, "%d Bytes", (int)size);

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -2444,7 +2444,7 @@ checkpoint:
 
 				/* print status */
 				if ((overall_progress > 0) && !progress_finished) {
-					if (overall_progress >= 100.0f) {
+					if (overall_progress >= 100.0F) {
 						progress_finished = 1;
 					}
 					print_progress_real(overall_progress, 0);


### PR DESCRIPTION
Found with readability-uppercase-literal-suffix

Signed-off-by: Rosen Penev <rosenp@gmail.com>