### PR TITLE
clang-tidy: use const pointer parameter

### DIFF
--- a/src/afc.c
+++ b/src/afc.c
@@ -354,7 +354,7 @@ static afc_error_t afc_receive_data(afc_client_t client, char **bytes, uint32_t 
 /**
  * Returns counts of null characters within a string.
  */
-static uint32_t count_nullspaces(char *string, uint32_t number)
+static uint32_t count_nullspaces(const char *string, uint32_t number)
 {
 	uint32_t i = 0, nulls = 0;
 

--- a/tools/ideviceprovision.c
+++ b/tools/ideviceprovision.c
@@ -106,7 +106,7 @@ static void asn1_next_item(unsigned char** p)
 	}
 }
 
-static size_t asn1_item_get_size(unsigned char* p)
+static size_t asn1_item_get_size(const unsigned char* p)
 {
 	size_t res = 0;
 	char bsize = *(p+1);

--- a/tools/idevicesyslog.c
+++ b/tools/idevicesyslog.c
@@ -171,7 +171,7 @@ static void add_filter(const char* filterstr)
 	}
 }
 
-static int find_char(char c, char** p, char* end)
+static int find_char(char c, char** p, const char* end)
 {
 	while ((**p != c) && (*p < end)) {
 		(*p)++;


### PR DESCRIPTION
Found with readability-non-const-parameter

Signed-off-by: Rosen Penev <rosenp@gmail.com>