### PR TITLE
clang-tidy: fix too small loop variable

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -211,7 +211,7 @@ char *string_format_size(uint64_t size)
 char *string_toupper(char* str)
 {
 	char *res = strdup(str);
-	unsigned int i;
+	size_t i;
 	for (i = 0; i < strlen(res); i++) {
 		res[i] = toupper(res[i]);
 	}


### PR DESCRIPTION
Found with bugprone-too-small-loop-variable

Signed-off-by: Rosen Penev <rosenp@gmail.com>