### PR TITLE
clang-tidy: add parentheses to macros

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -46,7 +46,7 @@ void internal_set_debug_level(int level)
 	debug_level = level;
 }
 
-#define MAX_PRINT_LEN 16*1024
+#define MAX_PRINT_LEN (16*1024)
 
 #ifndef STRIP_DEBUG_CODE
 static void debug_print_line(const char *func, const char *file, int line, const char *buffer)

--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -231,10 +231,10 @@ static char debugserver_int2hex(int x)
 	return hexchars[x];
 }
 
-#define DEBUGSERVER_HEX_ENCODE_FIRST_BYTE(byte) debugserver_int2hex((byte >> 0x4) & 0xf)
-#define DEBUGSERVER_HEX_ENCODE_SECOND_BYTE(byte) debugserver_int2hex(byte & 0xf)
-#define DEBUGSERVER_HEX_DECODE_FIRST_BYTE(byte) ((byte >> 0x4) & 0xf)
-#define DEBUGSERVER_HEX_DECODE_SECOND_BYTE(byte) (byte & 0xf)
+#define DEBUGSERVER_HEX_ENCODE_FIRST_BYTE(byte) debugserver_int2hex(((byte) >> 0x4) & 0xf)
+#define DEBUGSERVER_HEX_ENCODE_SECOND_BYTE(byte) debugserver_int2hex((byte) & 0xf)
+#define DEBUGSERVER_HEX_DECODE_FIRST_BYTE(byte) (((byte) >> 0x4) & 0xf)
+#define DEBUGSERVER_HEX_DECODE_SECOND_BYTE(byte) ((byte) & 0xf)
 
 static uint32_t debugserver_get_checksum_for_buffer(const char* buffer, uint32_t size)
 {

--- a/src/mobilebackup.c
+++ b/src/mobilebackup.c
@@ -34,7 +34,7 @@
 #define MBACKUP_VERSION_INT1 100
 #define MBACKUP_VERSION_INT2 0
 
-#define IS_FLAG_SET(x, y) ((x & y) == y)
+#define IS_FLAG_SET(x, y) (((x) & (y)) == (y))
 
 /**
  * Convert an device_link_service_error_t value to an mobilebackup_error_t value.

--- a/src/mobilebackup2.c
+++ b/src/mobilebackup2.c
@@ -33,7 +33,7 @@
 #define MBACKUP2_VERSION_INT1 400
 #define MBACKUP2_VERSION_INT2 0
 
-#define IS_FLAG_SET(x, y) ((x & y) == y)
+#define IS_FLAG_SET(x, y) (((x) & (y)) == (y))
 
 /**
  * Convert an device_link_service_error_t value to an mobilebackup2_error_t value.

--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -1456,7 +1456,7 @@ static void print_usage(int argc, char **argv)
 	printf("Bug Reports: <" PACKAGE_BUGREPORT ">\n");
 }
 
-#define DEVICE_VERSION(maj, min, patch) (((maj & 0xFF) << 16) | ((min & 0xFF) << 8) | (patch & 0xFF))
+#define DEVICE_VERSION(maj, min, patch) ((((maj) & 0xFF) << 16) | (((min) & 0xFF) << 8) | ((patch) & 0xFF))
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Found with bugprone-macro-parentheses

Signed-off-by: Rosen Penev <rosenp@gmail.com>