### PR TITLE
clang-tidy: fix improper *cmp usage

### DIFF
--- a/src/afc.c
+++ b/src/afc.c
@@ -234,7 +234,7 @@ static afc_error_t afc_receive_data(afc_client_t client, char **bytes, uint32_t 
 	}
 
 	/* check if it's a valid AFC header */
-	if (strncmp(header.magic, AFC_MAGIC, AFC_MAGIC_LEN)) {
+	if (strncmp(header.magic, AFC_MAGIC, AFC_MAGIC_LEN) != 0) {
 		debug_info("Invalid AFC packet received (magic != " AFC_MAGIC ")!");
 	}
 

--- a/src/device_link_service.c
+++ b/src/device_link_service.c
@@ -83,7 +83,7 @@ static int device_link_service_get_message(plist_t dl_msg, char **message)
 		return 0;
 	}
 
-	if ((strlen(cmd_str) < 9) || (strncmp(cmd_str, "DL", 2))) {
+	if ((strlen(cmd_str) < 9) || (strncmp(cmd_str, "DL", 2) != 0)) {
 		free(cmd_str);
 		return 0;
 	}
@@ -184,7 +184,7 @@ device_link_service_error_t device_link_service_version_exchange(device_link_ser
 		goto leave;
 	}
 	device_link_service_get_message(array, &msg);
-	if (!msg || strcmp(msg, "DLMessageVersionExchange")) {
+	if (!msg || strcmp(msg, "DLMessageVersionExchange") != 0) {
 		debug_info("Did not receive DLMessageVersionExchange from device!");
 		err = DEVICE_LINK_SERVICE_E_PLIST_ERROR;
 		goto leave;
@@ -239,7 +239,7 @@ device_link_service_error_t device_link_service_version_exchange(device_link_ser
 		goto leave;
 	}
 	device_link_service_get_message(array, &msg);
-	if (!msg || strcmp(msg, "DLMessageDeviceReady")) {
+	if (!msg || strcmp(msg, "DLMessageDeviceReady") != 0) {
 		debug_info("Did not get DLMessageDeviceReady!");
 		err = DEVICE_LINK_SERVICE_E_PLIST_ERROR;
 		goto leave;
@@ -403,7 +403,7 @@ device_link_service_error_t device_link_service_receive_process_message(device_l
 
 	char *msg = NULL;
 	device_link_service_get_message(pmsg, &msg);
-	if (!msg || strcmp(msg, "DLMessageProcessMessage")) {
+	if (!msg || strcmp(msg, "DLMessageProcessMessage") != 0) {
 		debug_info("Did not receive DLMessageProcessMessage as expected!");
 		err = DEVICE_LINK_SERVICE_E_PLIST_ERROR;
 		goto leave;

--- a/src/file_relay.c
+++ b/src/file_relay.c
@@ -143,7 +143,7 @@ LIBIMOBILEDEVICE_API file_relay_error_t file_relay_request_sources_timeout(file_
 		goto leave;
 	}
 
-	if (strcmp(ack, "Acknowledged")) {
+	if (strcmp(ack, "Acknowledged") != 0) {
 		debug_info("ERROR: Did not receive 'Acknowledged' but '%s'", ack);
 		goto leave;
 	}

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -678,7 +678,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new_with_handshake(idevi
 	ret = lockdownd_query_type(client_loc, &type);
 	if (LOCKDOWN_E_SUCCESS != ret) {
 		debug_info("QueryType failed in the lockdownd client.");
-	} else if (strcmp("com.apple.mobile.lockdown", type)) {
+	} else if (strcmp("com.apple.mobile.lockdown", type) != 0) {
 		debug_info("Warning QueryType request returned \"%s\".", type);
 	}
 	free(type);

--- a/src/mobilesync.c
+++ b/src/mobilesync.c
@@ -473,7 +473,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_clear_all_records_on_device(m
 		goto out;
 	}
 
-	if (strcmp(response_type, "SDMessageDeviceWillClearAllRecords")) {
+	if (strcmp(response_type, "SDMessageDeviceWillClearAllRecords") != 0) {
 		err = MOBILESYNC_E_PLIST_ERROR;
 	}
 

--- a/src/screenshotr.c
+++ b/src/screenshotr.c
@@ -142,7 +142,7 @@ LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_take_screenshot(screenshotr
 	plist_t node = plist_dict_get_item(dict, "MessageType");
 	char *strval = NULL;
 	plist_get_string_val(node, &strval);
-	if (!strval || strcmp(strval, "ScreenShotReply")) {
+	if (!strval || strcmp(strval, "ScreenShotReply") != 0) {
 		debug_info("invalid screenshot data received!");
 		res = SCREENSHOTR_E_PLIST_ERROR;
 		goto leave;

--- a/tools/idevicebackup.c
+++ b/tools/idevicebackup.c
@@ -548,7 +548,7 @@ static int mobilebackup_check_file_integrity(const char *backup_directory, const
 	for ( i = 0; i < 20; i++, p += 2 ) {
 		snprintf (p, 3, "%02x", (unsigned char)fnhash[i] );
 	}
-	if (strcmp(fnamehash, hash)) {
+	if (strcmp(fnamehash, hash) != 0) {
 		printf("\r\n");
 		printf("WARNING: filename hash does not match for entry '%s'\n", hash);
 	}
@@ -559,7 +559,7 @@ static int mobilebackup_check_file_integrity(const char *backup_directory, const
 		plist_get_string_val(node, &auth_version);
 	}
 
-	if (strcmp(auth_version, "1.0")) {
+	if (strcmp(auth_version, "1.0") != 0) {
 		printf("\r\n");
 		printf("WARNING: Unknown AuthVersion '%s', DataHash cannot be verified!\n", auth_version);
 	}

--- a/tools/idevicedebug.c
+++ b/tools/idevicedebug.c
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
 				debugserver_command_free(command);
 				command = NULL;
 				if (response) {
-					if (strncmp(response, "OK", 2)) {
+					if (strncmp(response, "OK", 2) != 0) {
 						debugserver_client_handle_response(debugserver_client, &response, 0);
 						goto cleanup;
 					}
@@ -387,7 +387,7 @@ int main(int argc, char *argv[])
 			debugserver_command_free(command);
 			command = NULL;
 			if (response) {
-				if (strncmp(response, "OK", 2)) {
+				if (strncmp(response, "OK", 2) != 0) {
 					debugserver_client_handle_response(debugserver_client, &response, 0);
 					goto cleanup;
 				}
@@ -403,7 +403,7 @@ int main(int argc, char *argv[])
 			debugserver_command_free(command);
 			command = NULL;
 			if (response) {
-				if (strncmp(response, "OK", 2)) {
+				if (strncmp(response, "OK", 2) != 0) {
 					debugserver_client_handle_response(debugserver_client, &response, 0);
 					goto cleanup;
 				}
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
 			debugserver_command_free(command);
 			command = NULL;
 			if (response) {
-				if (strncmp(response, "OK", 2)) {
+				if (strncmp(response, "OK", 2) != 0) {
 					debugserver_client_handle_response(debugserver_client, &response, 0);
 					goto cleanup;
 				}
@@ -470,7 +470,7 @@ int main(int argc, char *argv[])
 			debugserver_command_free(command);
 			command = NULL;
 			if (response) {
-				if (strncmp(response, "OK", 2)) {
+				if (strncmp(response, "OK", 2) != 0) {
 					debugserver_client_handle_response(debugserver_client, &response, 0);
 					goto cleanup;
 				}
@@ -508,7 +508,7 @@ int main(int argc, char *argv[])
 			debugserver_command_free(command);
 			command = NULL;
 			if (response) {
-				if (strncmp(response, "OK", 2)) {
+				if (strncmp(response, "OK", 2) != 0) {
 					debugserver_client_handle_response(debugserver_client, &response, 0);
 					goto cleanup;
 				}

--- a/tools/idevicepair.c
+++ b/tools/idevicepair.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 		result = EXIT_FAILURE;
 		goto leave;
 	} else {
-		if (strcmp("com.apple.mobile.lockdown", type)) {
+		if (strcmp("com.apple.mobile.lockdown", type) != 0) {
 			printf("WARNING: QueryType request returned '%s'\n", type);
 		}
 		free(type);


### PR DESCRIPTION
Found with bugprone-suspicious-string-compare

Signed-off-by: Rosen Penev <rosenp@gmail.com>