### PR TITLE
Remove redundent `select` call from idevicedebugserverproxy.c

### DIFF
--- a/common/socket.c
+++ b/common/socket.c
@@ -1084,8 +1084,6 @@ int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout)
 				return -1;
 			}
 		} else if (sret == 0) {
-			if (verbose >= 2)
-				fprintf(stderr, "%s: timeout\n", __func__);
 			return -ETIMEDOUT;
 		}
 	} while (eagain);

--- a/tools/idevicedebugserverproxy.c
+++ b/tools/idevicedebugserverproxy.c
@@ -121,15 +121,8 @@ static void* connection_handler(void* data)
 	int dtimeout = 1;
 
 	while (!quit_flag) {
-		fd_set read_fds = fds;
-		struct timeval tv = { 0, 1000 };
-		int ret_sel = select(client_fd+1, &read_fds, NULL, NULL, &tv);
-		if (ret_sel < 0) {
-			perror("select");
-			break;
-		}
-		if (FD_ISSET(client_fd, &read_fds)) {
-			ssize_t n = socket_receive(client_fd, buf, bufsize);
+		ssize_t n = socket_receive_timeout(client_fd, buf, bufsize, 0, 1);
+		if (n != -ETIMEDOUT) {
 			if (n < 0) {
 				fprintf(stderr, "Failed to read from client fd: %s\n", strerror(-n));
 				break;


### PR DESCRIPTION
- Turns out `socket_receive` anyway internally calls `select` again. Use `socket_receive_timeout` instead.
- Remove logging for timeout in socket.c as well, it is not really an error condition