### PR TITLE
Update afc.c

### DIFF
--- a/src/afc.c
+++ b/src/afc.c
@@ -283,6 +283,7 @@ static afc_error_t afc_receive_data(afc_client_t client, char **bytes, uint32_t 
 
 	if (entire_len > this_len) {
 		while (current_count < entire_len) {
+			*bytes_recv = 0;
 			service_receive(client->parent, dump_here+current_count, entire_len - current_count, bytes_recv);
 			if (*bytes_recv <= 0) {
 				debug_info("Error receiving data (recv returned %d)", *bytes_recv);


### PR DESCRIPTION
When the service_receive function fails, the size of bytes_recv will be fatal.