### PR TITLE
tools: Fix usage of LDFLAGS and LDADD.

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -40,8 +40,8 @@ bin_PROGRAMS = \
 
 ideviceinfo_SOURCES = ideviceinfo.c
 ideviceinfo_CFLAGS = $(AM_CFLAGS)
-ideviceinfo_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceinfo_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+ideviceinfo_LDFLAGS = $(AM_LDFLAGS)
+ideviceinfo_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicename_SOURCES = idevicename.c
 idevicename_CFLAGS = $(AM_CFLAGS)
@@ -50,8 +50,8 @@ idevicename_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicepair_SOURCES = idevicepair.c
 idevicepair_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicepair_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS) $(libusbmuxd_LIBS)
-idevicepair_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicepair_LDFLAGS = $(AM_LDFLAGS) $(libusbmuxd_LIBS)
+idevicepair_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicesyslog_SOURCES = idevicesyslog.c
 idevicesyslog_CFLAGS = $(AM_CFLAGS)
@@ -65,18 +65,18 @@ idevice_id_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicebackup_SOURCES = idevicebackup.c
 idevicebackup_CFLAGS = $(AM_CFLAGS)
-idevicebackup_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicebackup_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicebackup_LDFLAGS = $(AM_LDFLAGS)
+idevicebackup_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicebackup2_SOURCES = idevicebackup2.c
 idevicebackup2_CFLAGS = $(AM_CFLAGS)
-idevicebackup2_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicebackup2_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicebackup2_LDFLAGS = $(AM_LDFLAGS)
+idevicebackup2_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 ideviceimagemounter_SOURCES = ideviceimagemounter.c
 ideviceimagemounter_CFLAGS = $(AM_CFLAGS)
-ideviceimagemounter_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceimagemounter_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+ideviceimagemounter_LDFLAGS = $(AM_LDFLAGS)
+ideviceimagemounter_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicescreenshot_SOURCES = idevicescreenshot.c
 idevicescreenshot_CFLAGS = $(AM_CFLAGS)
@@ -95,13 +95,13 @@ idevicedate_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 ideviceprovision_SOURCES = ideviceprovision.c
 ideviceprovision_CFLAGS = $(AM_CFLAGS)
-ideviceprovision_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-ideviceprovision_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+ideviceprovision_LDFLAGS = $(AM_LDFLAGS)
+ideviceprovision_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicedebugserverproxy_SOURCES = idevicedebugserverproxy.c
 idevicedebugserverproxy_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicedebugserverproxy_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicedebugserverproxy_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicedebugserverproxy_LDFLAGS = $(AM_LDFLAGS)
+idevicedebugserverproxy_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicediagnostics_SOURCES = idevicediagnostics.c
 idevicediagnostics_CFLAGS = $(AM_CFLAGS)
@@ -110,8 +110,8 @@ idevicediagnostics_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicedebug_SOURCES = idevicedebug.c
 idevicedebug_CFLAGS = $(AM_CFLAGS)
-idevicedebug_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicedebug_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicedebug_LDFLAGS = $(AM_LDFLAGS)
+idevicedebug_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicenotificationproxy_SOURCES = idevicenotificationproxy.c
 idevicenotificationproxy_CFLAGS = $(AM_CFLAGS)
@@ -120,10 +120,10 @@ idevicenotificationproxy_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicecrashreport_SOURCES = idevicecrashreport.c
 idevicecrashreport_CFLAGS = -I$(top_srcdir) $(AM_CFLAGS)
-idevicecrashreport_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicecrashreport_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicecrashreport_LDFLAGS = $(AM_LDFLAGS)
+idevicecrashreport_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicesetlocation_SOURCES = idevicesetlocation.c
 idevicesetlocation_CFLAGS = $(AM_CFLAGS)
-idevicesetlocation_LDFLAGS = $(top_builddir)/common/libinternalcommon.la $(AM_LDFLAGS)
-idevicesetlocation_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
+idevicesetlocation_LDFLAGS = $(AM_LDFLAGS)
+idevicesetlocation_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la


### PR DESCRIPTION
When building libimobiledevice with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CC --mode=link gcc -Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith -Wwrite-strings -Wswitch-default -Wno-unused-parameter -fsigned-char -fvisibility=hidden -g -O2 ../common/libinternalcommon.la -lssl -lcrypto -lplist-2.0 -lplist -o ideviceinfo ideviceinfo-ideviceinfo.o ../src/libimobiledevice-1.0.la -lpthread

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/libimobiledevice/tools"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 9179}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 8958}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/libimobiledevice/libtool".
rdlibtool: link: gcc ../common/.libs/libinternalcommon.a ideviceinfo-ideviceinfo.o -Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith -Wwrite-strings -Wswitch-default -Wno-unused-parameter -fsigned-char -fvisibility=hidden -g -O2 -lusbmuxd-2.0 -lplist-2.0 -lplist -lpthread -lssl -lcrypto -lplist-2.0 -lplist -L../src/.libs -limobiledevice-1.0 -lplist-2.0 -lplist -lusbmuxd-2.0 -lssl -lcrypto -lpthread -o .libs/ideviceinfo
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ideviceinfo-ideviceinfo.o: in function `main':
/tmp/libimobiledevice/tools/ideviceinfo.c:243: undefined reference to `plist_print_to_stream'
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_executable(), line 1731: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 2051.
make[1]: *** [Makefile:749: ideviceinfo] Error 2
make[1]: Leaving directory '/tmp/libimobiledevice/tools'
make: *** [Makefile:455: install-recursive] Error 1
```
This is because `tools/Makefile.am` adds `libinternalcommon.la` to `LDFLAGS` when it should be in `LDADD`.

The correct way to link dependencies when using autotools is to add the linker flags or `.la` files to `foo_LIBADD` or `foo_LDADD` while `foo_LDFLAGS` is for all other linker arguments. GNU libtool is a lot more permissive and somehow works.