### PR TITLE
move LIBIMOBILEDEVICE_API into the headers

### DIFF
--- a/include/libimobiledevice/afc.h
+++ b/include/libimobiledevice/afc.h
@@ -106,7 +106,7 @@ typedef afc_client_private *afc_client_t; /**< The client handle. */
  *         invalid, AFC_E_MUX_ERROR if the connection cannot be established,
  *         or AFC_E_NO_MEM if there is a memory allocation problem.
  */
-afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t *client);
+LIBIMOBILEDEVICE_API afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t *client);
 
 /**
  * Starts a new AFC service on the specified device and connects to it.
@@ -119,7 +119,7 @@ afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t serv
  *
  * @return AFC_E_SUCCESS on success, or an AFC_E_* error code otherwise.
  */
-afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, const char* label);
 
 /**
  * Frees up an AFC client. If the connection was created by the client itself,
@@ -127,7 +127,7 @@ afc_error_t afc_client_start_service(idevice_t device, afc_client_t* client, con
  *
  * @param client The client to free.
  */
-afc_error_t afc_client_free(afc_client_t client);
+LIBIMOBILEDEVICE_API afc_error_t afc_client_free(afc_client_t client);
 
 /**
  * Get device information for a connected client. The device information
@@ -141,7 +141,7 @@ afc_error_t afc_client_free(afc_client_t client);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_device_info(afc_client_t client, char ***device_information);
+LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info(afc_client_t client, char ***device_information);
 
 /**
  * Gets a directory listing of the directory requested.
@@ -154,7 +154,7 @@ afc_error_t afc_get_device_info(afc_client_t client, char ***device_information)
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information);
+LIBIMOBILEDEVICE_API afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information);
 
 /**
  * Gets information about a specific file.
@@ -167,7 +167,7 @@ afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***di
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_file_info(afc_client_t client, const char *path, char ***file_information);
+LIBIMOBILEDEVICE_API afc_error_t afc_get_file_info(afc_client_t client, const char *path, char ***file_information);
 
 /**
  * Opens a file on the device.
@@ -179,7 +179,7 @@ afc_error_t afc_get_file_info(afc_client_t client, const char *path, char ***fil
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle);
 
 /**
  * Closes a file on the device.
@@ -187,7 +187,7 @@ afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mo
  * @param client The client to close the file with.
  * @param handle File handle of a previously opened file.
  */
-afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
 
 /**
  * Locks or unlocks a file on the device.
@@ -201,7 +201,7 @@ afc_error_t afc_file_close(afc_client_t client, uint64_t handle);
  *        AFC_LOCK_SH (shared lock), AFC_LOCK_EX (exclusive lock), or
  *        AFC_LOCK_UN (unlock).
  */
-afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation);
 
 /**
  * Attempts to the read the given number of bytes from the given file.
@@ -214,7 +214,7 @@ afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t op
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read);
 
 /**
  * Writes a given number of bytes to a file.
@@ -227,7 +227,7 @@ afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written);
 
 /**
  * Seeks to a given position of a pre-opened file on the device.
@@ -239,7 +239,7 @@ afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *dat
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence);
 
 /**
  * Returns current position in a pre-opened file on the device.
@@ -250,7 +250,7 @@ afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, 
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position);
 
 /**
  * Sets the size of a file on the device.
@@ -264,7 +264,7 @@ afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *positi
  * @note This function is more akin to ftruncate than truncate, and truncate
  *       calls would have to open the file before calling this, sadly.
  */
-afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize);
+LIBIMOBILEDEVICE_API afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize);
 
 /**
  * Deletes a file or directory.
@@ -274,7 +274,7 @@ afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t new
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_remove_path(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API afc_error_t afc_remove_path(afc_client_t client, const char *path);
 
 /**
  * Renames a file or directory on the device.
@@ -285,7 +285,7 @@ afc_error_t afc_remove_path(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to);
+LIBIMOBILEDEVICE_API afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to);
 
 /**
  * Creates a directory on the device.
@@ -296,7 +296,7 @@ afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *t
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_make_directory(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API afc_error_t afc_make_directory(afc_client_t client, const char *path);
 
 /**
  * Sets the size of a file on the device without prior opening it.
@@ -307,7 +307,7 @@ afc_error_t afc_make_directory(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize);
+LIBIMOBILEDEVICE_API afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize);
 
 /**
  * Creates a hard link or symbolic link on the device.
@@ -319,7 +319,7 @@ afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname);
+LIBIMOBILEDEVICE_API afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname);
 
 /**
  * Sets the modification time of a file on the device.
@@ -330,7 +330,7 @@ afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const c
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime);
+LIBIMOBILEDEVICE_API afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime);
 
 /**
  * Deletes a file or directory including possible contents.
@@ -342,7 +342,7 @@ afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mt
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
+LIBIMOBILEDEVICE_API afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
 
 /* Helper functions */
 
@@ -357,7 +357,7 @@ afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path);
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value);
+LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value);
 
 /**
  * Frees up a char dictionary as returned by some AFC functions.
@@ -366,7 +366,7 @@ afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char *
  *
  * @return AFC_E_SUCCESS on success or an AFC_E_* error value.
  */
-afc_error_t afc_dictionary_free(char **dictionary);
+LIBIMOBILEDEVICE_API afc_error_t afc_dictionary_free(char **dictionary);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/companion_proxy.h
+++ b/include/libimobiledevice/companion_proxy.h
@@ -65,7 +65,7 @@ typedef void (*companion_proxy_device_event_cb_t) (plist_t event, void* userdata
  * @return COMPANION_PROXY_E_SUCCESS on success, COMPANION_PROXY_E_INVALID_ARG when
  *     the arguments are invalid, or an COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, companion_proxy_client_t* client);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, companion_proxy_client_t* client);
 
 /**
  * Starts a new companion_proxy service on the specified device and connects to it.
@@ -80,7 +80,7 @@ companion_proxy_error_t companion_proxy_client_new(idevice_t device, lockdownd_s
  * @return COMPANION_PROXY_E_SUCCESS on success, or an COMPANION_PROXY_E_* error
  *     code otherwise.
  */
-companion_proxy_error_t companion_proxy_client_start_service(idevice_t device, companion_proxy_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_start_service(idevice_t device, companion_proxy_client_t* client, const char* label);
 
 /**
  * Disconnects a companion_proxy client from the device and frees up the
@@ -91,7 +91,7 @@ companion_proxy_error_t companion_proxy_client_start_service(idevice_t device, c
  * @return COMPANION_PROXY_E_SUCCESS on success, COMPANION_PROXY_E_INVALID_ARG when
  *     client is NULL, or an COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_client_free(companion_proxy_client_t client);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_free(companion_proxy_client_t client);
 
 /**
  * Sends a plist to the service.
@@ -102,7 +102,7 @@ companion_proxy_error_t companion_proxy_client_free(companion_proxy_client_t cli
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  COMPANION_PROXY_E_INVALID_ARG when client or plist is NULL
  */
-companion_proxy_error_t companion_proxy_send(companion_proxy_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_send(companion_proxy_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -113,7 +113,7 @@ companion_proxy_error_t companion_proxy_send(companion_proxy_client_t client, pl
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  COMPANION_PROXY_E_INVALID_ARG when client or plist is NULL
  */
-companion_proxy_error_t companion_proxy_receive(companion_proxy_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_receive(companion_proxy_client_t client, plist_t * plist);
 
 /**
  * Retrieves a list of paired devices.
@@ -127,7 +127,7 @@ companion_proxy_error_t companion_proxy_receive(companion_proxy_client_t client,
  *  COMPANION_PROXY_E_NO_DEVICES if no devices are paired,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_get_device_registry(companion_proxy_client_t client, plist_t* paired_devices);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_get_device_registry(companion_proxy_client_t client, plist_t* paired_devices);
 
 /**
  * Starts listening for paired devices.
@@ -143,7 +143,7 @@ companion_proxy_error_t companion_proxy_get_device_registry(companion_proxy_clie
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_start_listening_for_devices(companion_proxy_client_t client, companion_proxy_device_event_cb_t callback, void* userdata);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_listening_for_devices(companion_proxy_client_t client, companion_proxy_device_event_cb_t callback, void* userdata);
 
 /**
  * Stops listening for paired devices
@@ -153,7 +153,7 @@ companion_proxy_error_t companion_proxy_start_listening_for_devices(companion_pr
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_stop_listening_for_devices(companion_proxy_client_t client);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_stop_listening_for_devices(companion_proxy_client_t client);
 
 /**
  * Returns a value for the given key.
@@ -169,7 +169,7 @@ companion_proxy_error_t companion_proxy_stop_listening_for_devices(companion_pro
  *  COMPANION_PROXY_E_UNSUPPORTED_KEY if the companion device doesn't support the given key,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_get_value_from_registry(companion_proxy_client_t client, const char* companion_udid, const char* key, plist_t* value);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_get_value_from_registry(companion_proxy_client_t client, const char* companion_udid, const char* key, plist_t* value);
 
 /**
  * Start forwarding a service port on the companion device to a port on the idevice.
@@ -186,7 +186,7 @@ companion_proxy_error_t companion_proxy_get_value_from_registry(companion_proxy_
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_start_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port, const char* service_name, uint16_t* forward_port, plist_t options);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port, const char* service_name, uint16_t* forward_port, plist_t options);
 
 /**
  * Stop forwarding a service port between companion device and idevice.
@@ -199,7 +199,7 @@ companion_proxy_error_t companion_proxy_start_forwarding_service_port(companion_
  * @return COMPANION_PROXY_E_SUCCESS on success,
  *  or a COMPANION_PROXY_E_* error code otherwise.
  */
-companion_proxy_error_t companion_proxy_stop_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port);
+LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_stop_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/debugserver.h
+++ b/include/libimobiledevice/debugserver.h
@@ -64,7 +64,7 @@ typedef debugserver_command_private *debugserver_command_t; /**< The command han
  * @return DEBUGSERVER_E_SUCCESS on success, DEBUGSERVER_E_INVALID_ARG when
  *     client is NULL, or an DEBUGSERVER_E_* error code otherwise.
  */
-debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t * client);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t * client);
 
 /**
  * Starts a new debugserver service on the specified device and connects to it.
@@ -79,7 +79,7 @@ debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_d
  * @return DEBUGSERVER_E_SUCCESS on success, or an DEBUGSERVER_E_* error
  *     code otherwise.
  */
-debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label);
 
 /**
  * Disconnects a debugserver client from the device and frees up the
@@ -90,7 +90,7 @@ debugserver_error_t debugserver_client_start_service(idevice_t device, debugserv
  * @return DEBUGSERVER_E_SUCCESS on success, DEBUGSERVER_E_INVALID_ARG when
  *     client is NULL, or an DEBUGSERVER_E_* error code otherwise.
  */
-debugserver_error_t debugserver_client_free(debugserver_client_t client);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_free(debugserver_client_t client);
 
 /**
  * Sends raw data using the given debugserver service client.
@@ -105,7 +105,7 @@ debugserver_error_t debugserver_client_free(debugserver_client_t client);
  *      invalid, or DEBUGSERVER_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent);
 
 /**
  * Receives raw data using the given debugserver client with specified timeout.
@@ -122,7 +122,7 @@ debugserver_error_t debugserver_client_send(debugserver_client_t client, const c
  *      occurs, or DEBUGSERVER_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives raw data from the debugserver service.
@@ -136,7 +136,7 @@ debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client or plist is NULL
  */
-debugserver_error_t debugserver_client_receive(debugserver_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive(debugserver_client_t client, char *data, uint32_t size, uint32_t *received);
 
 /**
  * Sends a command to the debugserver service.
@@ -149,7 +149,7 @@ debugserver_error_t debugserver_client_receive(debugserver_client_t client, char
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client or command is NULL
  */
-debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response, size_t* response_size);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response, size_t* response_size);
 
 /**
  * Receives and parses response of debugserver service.
@@ -161,7 +161,7 @@ debugserver_error_t debugserver_client_send_command(debugserver_client_t client,
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response, size_t* response_size);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response, size_t* response_size);
 
 /**
  * Controls status of ACK mode when sending commands or receiving responses.
@@ -175,7 +175,7 @@ debugserver_error_t debugserver_client_receive_response(debugserver_client_t cli
  * @return DEBUGSERVER_E_SUCCESS on success, or an DEBUGSERVER_E_* error
  *     code otherwise.
  */
-debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled);
 
 /**
  * Sets the argv which launches an app.
@@ -188,7 +188,7 @@ debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client,
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response);
 
 /**
  * Adds or sets an environment variable.
@@ -200,7 +200,7 @@ debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when client is NULL
  */
-debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response);
 
 /**
  * Creates and initializes a new command object.
@@ -213,7 +213,7 @@ debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_c
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when name or command is NULL
  */
-debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command);
 
 /**
  * Frees memory of command object.
@@ -223,7 +223,7 @@ debugserver_error_t debugserver_command_new(const char* name, int argc, char* ar
  * @return DEBUGSERVER_E_SUCCESS on success,
  *  DEBUGSERVER_E_INVALID_ARG when command is NULL
  */
-debugserver_error_t debugserver_command_free(debugserver_command_t command);
+LIBIMOBILEDEVICE_API debugserver_error_t debugserver_command_free(debugserver_command_t command);
 
 /**
  * Encodes a string into hex notation.
@@ -232,7 +232,7 @@ debugserver_error_t debugserver_command_free(debugserver_command_t command);
  * @param encoded_buffer The buffer receives a hex encoded string
  * @param encoded_length Length of the hex encoded string
  */
-void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length);
+LIBIMOBILEDEVICE_API void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length);
 
 /**
  * Decodes a hex encoded string.
@@ -241,7 +241,7 @@ void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32
  * @param encoded_length Length of the encoded buffer
  * @param buffer Decoded string to be freed by the caller
  */
-void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer);
+LIBIMOBILEDEVICE_API void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/diagnostics_relay.h
+++ b/include/libimobiledevice/diagnostics_relay.h
@@ -68,7 +68,7 @@ typedef diagnostics_relay_client_private *diagnostics_relay_client_t; /**< The c
  *     DIAGNOSTICS_RELAY_E_INVALID_ARG when one of the parameters is invalid,
  *     or DIAGNOSTICS_RELAY_E_MUX_ERROR when the connection failed.
  */
-diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client);
 
 /**
  * Starts a new diagnostics_relay service on the specified device and connects to it.
@@ -83,7 +83,7 @@ diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdow
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success, or an DIAGNOSTICS_RELAY_E_* error
  *     code otherwise.
  */
-diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t* client, const char* label);
 
 /**
  * Disconnects a diagnostics_relay client from the device and frees up the
@@ -96,7 +96,7 @@ diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t devic
  *     is invalid, or DIAGNOSTICS_RELAY_E_UNKNOWN_ERROR when the was an
  *     error freeing the parent property_list_service client.
  */
-diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client);
 
 
 /**
@@ -109,7 +109,7 @@ diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client);
 
 /**
  * Puts the device into deep sleep mode and disconnects from host.
@@ -121,7 +121,7 @@ diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t c
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client);
 
 /**
  * Restart the device and optionally show a user notification.
@@ -138,7 +138,7 @@ diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t cli
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.
@@ -155,7 +155,7 @@ diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t c
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags);
 
 /**
  * Shutdown of the device and optionally show a user notification.
@@ -172,13 +172,13 @@ diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t 
  *  DIAGNOSTICS_RELAY_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics);
 
-diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result);
 
-diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* entry_name, const char* entry_class, plist_t* result);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* entry_name, const char* entry_class, plist_t* result);
 
-diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result);
+LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/file_relay.h
+++ b/include/libimobiledevice/file_relay.h
@@ -61,7 +61,7 @@ typedef file_relay_client_private *file_relay_client_t; /**< The client handle. 
  *     FILE_RELAY_E_INVALID_ARG when one of the parameters is invalid,
  *     or FILE_RELAY_E_MUX_ERROR when the connection failed.
  */
-file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client);
+LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client);
 
 /**
  * Starts a new file_relay service on the specified device and connects to it.
@@ -76,7 +76,7 @@ file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_des
  * @return FILE_RELAY_E_SUCCESS on success, or an FILE_RELAY_E_* error
  *     code otherwise.
  */
-file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t* client, const char* label);
 
 /**
  * Disconnects a file_relay client from the device and frees up the file_relay
@@ -89,7 +89,7 @@ file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_
  *     is invalid, or FILE_RELAY_E_UNKNOWN_ERROR when the was an error
  *     freeing the parent property_list_service client.
  */
-file_relay_error_t file_relay_client_free(file_relay_client_t client);
+LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_free(file_relay_client_t client);
 
 
 /**
@@ -123,7 +123,7 @@ file_relay_error_t file_relay_client_free(file_relay_client_t client);
  *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
  *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
  */
-file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection);
+LIBIMOBILEDEVICE_API file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection);
 
 /**
  * Request data for the given sources. Calls file_relay_request_sources_timeout() with
@@ -156,7 +156,7 @@ file_relay_error_t file_relay_request_sources(file_relay_client_t client, const 
  *     sources are invalid, FILE_RELAY_E_STAGING_EMPTY if no data is available
  *     for the given sources, or FILE_RELAY_E_UNKNOWN_ERROR otherwise.
  */
-file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout);
+LIBIMOBILEDEVICE_API file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/heartbeat.h
+++ b/include/libimobiledevice/heartbeat.h
@@ -59,7 +59,7 @@ typedef heartbeat_client_private *heartbeat_client_t; /**< The client handle. */
  * @return HEARTBEAT_E_SUCCESS on success, HEARTBEAT_E_INVALID_ARG when
  *     client is NULL, or an HEARTBEAT_E_* error code otherwise.
  */
-heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client);
 
 /**
  * Starts a new heartbeat service on the specified device and connects to it.
@@ -74,7 +74,7 @@ heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descr
  * @return HEARTBEAT_E_SUCCESS on success, or an HEARTBEAT_E_* error
  *     code otherwise.
  */
-heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label);
 
 /**
  * Disconnects a heartbeat client from the device and frees up the
@@ -85,7 +85,7 @@ heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_cli
  * @return HEARTBEAT_E_SUCCESS on success, HEARTBEAT_E_INVALID_ARG when
  *     client is NULL, or an HEARTBEAT_E_* error code otherwise.
  */
-heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
 
 
 /**
@@ -97,7 +97,7 @@ heartbeat_error_t heartbeat_client_free(heartbeat_client_t client);
  * @return HEARTBEAT_E_SUCCESS on success,
  *  HEARTBEAT_E_INVALID_ARG when client or plist is NULL
  */
-heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -108,7 +108,7 @@ heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist);
  * @return HEARTBEAT_E_SUCCESS on success,
  *  HEARTBEAT_E_INVALID_ARG when client or plist is NULL
  */
-heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
 
 /**
  * Receives a plist using the given heartbeat client.
@@ -127,7 +127,7 @@ heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist);
  *      communication error occurs, or HEARTBEAT_E_UNKNOWN_ERROR
  *      when an unspecified error occurs.
  */
-heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms);
+LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/house_arrest.h
+++ b/include/libimobiledevice/house_arrest.h
@@ -60,7 +60,7 @@ typedef house_arrest_client_private *house_arrest_client_t; /**< The client hand
  * @return HOUSE_ARREST_E_SUCCESS on success, HOUSE_ARREST_E_INVALID_ARG when
  *     client is NULL, or an HOUSE_ARREST_E_* error code otherwise.
  */
-house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client);
 
 /**
  * Starts a new house_arrest service on the specified device and connects to it.
@@ -75,7 +75,7 @@ house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service
  * @return HOUSE_ARREST_E_SUCCESS on success, or an HOUSE_ARREST_E_* error
  *     code otherwise.
  */
-house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t* client, const char* label);
 
 /**
  * Disconnects an house_arrest client from the device and frees up the
@@ -91,7 +91,7 @@ house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_a
  * @return HOUSE_ARREST_E_SUCCESS on success, HOUSE_ARREST_E_INVALID_ARG when
  *     client is NULL, or an HOUSE_ARREST_E_* error code otherwise.
  */
-house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
 
 
 /**
@@ -111,7 +111,7 @@ house_arrest_error_t house_arrest_client_free(house_arrest_client_t client);
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occurred.
  */
-house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict);
 
 /**
  * Send a command to the connected house_arrest service.
@@ -132,7 +132,7 @@ house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, pli
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occurred.
  */
-house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid);
 
 /**
  * Retrieves the result of a previously sent house_arrest_request_* request.
@@ -148,7 +148,7 @@ house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, con
  *     HOUSE_ARREST_E_INVALID_MODE if the client is not in the correct mode,
  *     or HOUSE_ARREST_E_CONN_FAILED if a connection error occurred.
  */
-house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict);
+LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict);
 
 
 /**
@@ -170,7 +170,7 @@ house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist
  *     an afc client, or an AFC_E_* error code returned by
  *     afc_client_new_with_service_client().
  */
-afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client);
+LIBIMOBILEDEVICE_API afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/installation_proxy.h
+++ b/include/libimobiledevice/installation_proxy.h
@@ -126,7 +126,7 @@ typedef void (*instproxy_status_cb_t) (plist_t command, plist_t status, void *us
  * @return INSTPROXY_E_SUCCESS on success, or an INSTPROXY_E_* error value
  *         when an error occurred.
  */
-instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client);
 
 /**
  * Starts a new installation_proxy service on the specified device and connects to it.
@@ -141,7 +141,7 @@ instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descr
  * @return INSTPROXY_E_SUCCESS on success, or an INSTPROXY_E_* error
  *         code otherwise.
  */
-instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label);
 
 /**
  * Disconnects an installation_proxy client from the device and frees up the
@@ -152,7 +152,7 @@ instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_cli
  * @return INSTPROXY_E_SUCCESS on success
  *         or INSTPROXY_E_INVALID_ARG if client is NULL.
  */
-instproxy_error_t instproxy_client_free(instproxy_client_t client);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_free(instproxy_client_t client);
 
 /**
  * List installed applications. This function runs synchronously.
@@ -170,7 +170,7 @@ instproxy_error_t instproxy_client_free(instproxy_client_t client);
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occurred.
  */
-instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result);
 
 /**
  * List pages of installed applications in a callback.
@@ -189,7 +189,7 @@ instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_opt
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occurred.
  */
-instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Lookup information about specific applications from the device.
@@ -205,7 +205,7 @@ instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plis
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occurred.
  */
-instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result);
 
 /**
  * Install an application on the device.
@@ -231,7 +231,7 @@ instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appid
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Upgrade an application on the device. This function is nearly the same as
@@ -259,7 +259,7 @@ instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_p
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Uninstall an application from the device.
@@ -280,7 +280,7 @@ instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_p
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * List archived applications. This function runs synchronously.
@@ -296,7 +296,7 @@ instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *app
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occurred.
  */
-instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result);
 
 /**
  * Archive an application on the device.
@@ -322,7 +322,7 @@ instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t c
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Restore a previously archived application on the device.
@@ -346,7 +346,7 @@ instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Removes a previously archived application from the device.
@@ -369,7 +369,7 @@ instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid
  *       created successfully; any error occurring during the command has to be
  *       handled inside the specified callback function.
  */
-instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data);
 
 /**
  * Checks a device for certain capabilities.
@@ -385,7 +385,7 @@ instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char
  * @return INSTPROXY_E_SUCCESS on success or an INSTPROXY_E_* error value if
  *         an error occurred.
  */
-instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result);
 
 /* Helper */
 
@@ -395,7 +395,7 @@ instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, 
  * @param command The dictionary describing the command.
  * @param name Pointer to store the name of the command.
  */
-void instproxy_command_get_name(plist_t command, char** name);
+LIBIMOBILEDEVICE_API void instproxy_command_get_name(plist_t command, char** name);
 
 /**
  * Gets the name of a status.
@@ -403,7 +403,7 @@ void instproxy_command_get_name(plist_t command, char** name);
  * @param status The dictionary status response to use.
  * @param name Pointer to store the name of the status.
  */
-void instproxy_status_get_name(plist_t status, char **name);
+LIBIMOBILEDEVICE_API void instproxy_status_get_name(plist_t status, char **name);
 
 /**
  * Gets error name, code and description from a response if available.
@@ -419,7 +419,7 @@ void instproxy_status_get_name(plist_t status, char **name);
  * @return INSTPROXY_E_SUCCESS if no error is found or an INSTPROXY_E_* error
  *   value matching the error that ẃas found in the status.
  */
-instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code);
 
 /**
  * Gets total and current item information from a browse response if available.
@@ -434,7 +434,7 @@ instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char**
  *        If NULL is passed no list will be returned. If NULL is returned no
  *        list was found in the status.
  */
-void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list);
+LIBIMOBILEDEVICE_API void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list);
 
 
 /**
@@ -444,14 +444,14 @@ void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t
  * @param name Pointer to store the progress in percent (0-100) or -1 if not
  *        progress was found in the status.
  */
-void instproxy_status_get_percent_complete(plist_t status, int *percent);
+LIBIMOBILEDEVICE_API void instproxy_status_get_percent_complete(plist_t status, int *percent);
 
 /**
  * Creates a new client_options plist.
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t instproxy_client_options_new(void);
+LIBIMOBILEDEVICE_API plist_t instproxy_client_options_new(void);
 
 /**
  * Adds one or more new key:value pairs to the given client_options.
@@ -463,7 +463,7 @@ plist_t instproxy_client_options_new(void);
  *       keys "ApplicationSINF", "iTunesMetadata", "ReturnAttributes" which are
  *       expecting a plist_t node as value and "SkipUninstall" expects int.
  */
-void instproxy_client_options_add(plist_t client_options, ...);
+LIBIMOBILEDEVICE_API void instproxy_client_options_add(plist_t client_options, ...);
 
 /**
  * Adds attributes to the given client_options to filter browse results.
@@ -473,7 +473,7 @@ void instproxy_client_options_add(plist_t client_options, ...);
  *
  * @note The values passed are expected to be strings.
  */
-void instproxy_client_options_set_return_attributes(plist_t client_options, ...);
+LIBIMOBILEDEVICE_API void instproxy_client_options_set_return_attributes(plist_t client_options, ...);
 
 /**
  * Frees client_options plist.
@@ -481,7 +481,7 @@ void instproxy_client_options_set_return_attributes(plist_t client_options, ...)
  * @param client_options The client options plist to free. Does nothing if NULL
  *        is passed.
  */
-void instproxy_client_options_free(plist_t client_options);
+LIBIMOBILEDEVICE_API void instproxy_client_options_free(plist_t client_options);
 
 /**
  * Queries the device for the path of an application.
@@ -495,7 +495,7 @@ void instproxy_client_options_free(plist_t client_options);
  *         the path could not be determined or an INSTPROXY_E_* error
  *         value if an error occurred.
  */
-instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* bundle_id, char** path);
+LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* bundle_id, char** path);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -35,6 +35,16 @@ extern "C" {
 #include <sys/stat.h>
 #include <plist/plist.h>
 
+#ifdef WIN32
+#define LIBIMOBILEDEVICE_API __declspec( dllexport )
+#else
+#ifdef HAVE_FVISIBILITY
+#define LIBIMOBILEDEVICE_API __attribute__((visibility("default")))
+#else
+#define LIBIMOBILEDEVICE_API
+#endif
+#endif
+
 /** Error Codes */
 typedef enum {
 	IDEVICE_E_SUCCESS         =  0,
@@ -99,7 +109,7 @@ typedef void (*idevice_event_cb_t) (const idevice_event_t *event, void *user_dat
  *
  * @param level Set to 0 for no debug output or 1 to enable debug output.
  */
-void idevice_set_debug_level(int level);
+LIBIMOBILEDEVICE_API void idevice_set_debug_level(int level);
 
 /**
  * Register a callback function that will be called when device add/remove
@@ -111,7 +121,7 @@ void idevice_set_debug_level(int level);
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occurred.
  */
-idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data);
 
 /**
  * Release the event callback function that has been registered with
@@ -119,7 +129,7 @@ idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occurred.
  */
-idevice_error_t idevice_event_unsubscribe(void);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_event_unsubscribe(void);
 
 /* discovery (synchronous) */
 
@@ -136,7 +146,7 @@ idevice_error_t idevice_event_unsubscribe(void);
  *   network devices in the list, use idevice_get_device_list_extended().
  * @see idevice_get_device_list_extended
  */
-idevice_error_t idevice_get_device_list(char ***devices, int *count);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list(char ***devices, int *count);
 
 /**
  * Free a list of device UDIDs.
@@ -145,7 +155,7 @@ idevice_error_t idevice_get_device_list(char ***devices, int *count);
  *
  * @return Always returnes IDEVICE_E_SUCCESS.
  */
-idevice_error_t idevice_device_list_free(char **devices);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_free(char **devices);
 
 /**
  * Get a list of currently available devices
@@ -156,7 +166,7 @@ idevice_error_t idevice_device_list_free(char **devices);
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occurred.
  */
-idevice_error_t idevice_get_device_list_extended(idevice_info_t **devices, int *count);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list_extended(idevice_info_t **devices, int *count);
 
 /**
  * Free an extended device list retrieved through idevice_get_device_list_extended().
@@ -165,7 +175,7 @@ idevice_error_t idevice_get_device_list_extended(idevice_info_t **devices, int *
  *
  * @return IDEVICE_E_SUCCESS on success or an error value when an error occurred.
  */
-idevice_error_t idevice_device_list_extended_free(idevice_info_t *devices);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_extended_free(idevice_info_t *devices);
 
 /* device structure creation and destruction */
 
@@ -186,7 +196,7 @@ idevice_error_t idevice_device_list_extended_free(idevice_info_t *devices);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_new(idevice_t *device, const char *udid);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_new(idevice_t *device, const char *udid);
 
 /**
  * Creates an idevice_t structure for the device specified by UDID,
@@ -209,14 +219,14 @@ idevice_error_t idevice_new(idevice_t *device, const char *udid);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_new_with_options(idevice_t *device, const char *udid, enum idevice_options options);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_new_with_options(idevice_t *device, const char *udid, enum idevice_options options);
 
 /**
  * Cleans up an idevice structure, then frees the structure itself.
  *
  * @param device idevice_t to free.
  */
-idevice_error_t idevice_free(idevice_t device);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_free(idevice_t device);
 
 /* connection/disconnection */
 
@@ -230,7 +240,7 @@ idevice_error_t idevice_free(idevice_t device);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection);
 
 /**
  * Disconnect from the device and clean up the connection structure.
@@ -239,7 +249,7 @@ idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connect
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_disconnect(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_disconnect(idevice_connection_t connection);
 
 /* communication */
 
@@ -254,7 +264,7 @@ idevice_error_t idevice_disconnect(idevice_connection_t connection);
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes);
 
 /**
  * Receive data from a device via the given connection.
@@ -271,7 +281,7 @@ idevice_error_t idevice_connection_send(idevice_connection_t connection, const c
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout);
 
 /**
  * Receive data from a device via the given connection.
@@ -286,7 +296,7 @@ idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connecti
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes);
 
 /**
  * Enables SSL for the given connection.
@@ -297,7 +307,7 @@ idevice_error_t idevice_connection_receive(idevice_connection_t connection, char
  *     is NULL or connection->ssl_data is non-NULL, or IDEVICE_E_SSL_ERROR when
  *     SSL initialization, setup, or handshake fails.
  */
-idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
 
 /**
  * Disable SSL for the given connection.
@@ -308,7 +318,7 @@ idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection);
  *     is NULL. This function also returns IDEVICE_E_SUCCESS when SSL is not
  *     enabled and does no further error checking on cleanup.
  */
-idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
 
 /**
  * Disable bypass SSL for the given connection without sending out terminate messages.
@@ -321,7 +331,7 @@ idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection);
  *     is NULL. This function also returns IDEVICE_E_SUCCESS when SSL is not
  *     enabled and does no further error checking on cleanup.
  */
-idevice_error_t idevice_connection_disable_bypass_ssl(idevice_connection_t connection, uint8_t sslBypass);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_disable_bypass_ssl(idevice_connection_t connection, uint8_t sslBypass);
 
 
 /**
@@ -332,19 +342,19 @@ idevice_error_t idevice_connection_disable_bypass_ssl(idevice_connection_t conne
  *
  * @return IDEVICE_E_SUCCESS if ok, otherwise an error code.
  */
-idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd);
 
 /* misc */
 
 /**
  * Gets the handle or (usbmux device id) of the device.
  */
-idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle);
 
 /**
  * Gets the unique id for the device.
  */
-idevice_error_t idevice_get_udid(idevice_t device, char **udid);
+LIBIMOBILEDEVICE_API idevice_error_t idevice_get_udid(idevice_t device, char **udid);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/lockdown.h
+++ b/include/libimobiledevice/lockdown.h
@@ -117,7 +117,7 @@ typedef struct lockdownd_service_descriptor *lockdownd_service_descriptor_t;
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label);
 
 /**
  * Creates a new lockdownd client for the device and starts initial handshake.
@@ -136,7 +136,7 @@ lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *cli
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL,
  *  LOCKDOWN_E_INVALID_CONF if configuration data is wrong
  */
-lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label);
 
 /**
  * Closes the lockdownd client session if one is running and frees up the
@@ -146,7 +146,7 @@ lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdown
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
 
 
 /**
@@ -158,7 +158,7 @@ lockdownd_error_t lockdownd_client_free(lockdownd_client_t client);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
 
 /**
  * Retrieves a preferences plist using an optional domain and/or key name.
@@ -170,7 +170,7 @@ lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value);
 
 /**
  * Sets a preferences value using a plist and optional by domain and/or key name.
@@ -183,7 +183,7 @@ lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *dom
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  value is NULL
  */
-lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value);
 
 /**
  * Removes a preference node by domain and/or key name.
@@ -196,7 +196,7 @@ lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *dom
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key);
 
 /**
  * Requests to start a service and retrieve it's port on success.
@@ -210,7 +210,7 @@ lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *
  *  by the device, LOCKDOWN_E_START_SERVICE_FAILED if the service could not be
  *  started by the device
  */
-lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
 
 /**
  * Requests to start a service and retrieve it's port on success.
@@ -226,7 +226,7 @@ lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char 
  *  started by the device, LOCKDOWN_E_INVALID_CONF if the host id or escrow bag are
  *  missing from the device record.
  */
-lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service);
 
 /**
  * Opens a session with lockdownd and switches to SSL mode if device wants it.
@@ -241,7 +241,7 @@ lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t cli
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the supplied HostID,
  *  LOCKDOWN_E_SSL_ERROR if enabling SSL communication failed
  */
-lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled);
 
 /**
  * Closes the lockdownd session by sending the StopSession request.
@@ -253,7 +253,7 @@ lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char 
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id);
 
 /**
  * Sends a plist to lockdownd.
@@ -267,7 +267,7 @@ lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  plist is NULL
  */
-lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
 
 /**
  * Receives a plist from lockdownd.
@@ -278,7 +278,7 @@ lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist);
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client or
  *  plist is NULL
  */
-lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
 
 /**
  * Pairs the device using the supplied pair record.
@@ -294,7 +294,7 @@ lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist);
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
  /**
  * Pairs the device using the supplied pair record and passing the given options.
@@ -313,7 +313,7 @@ lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_recor
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_pair_with_options(lockdownd_client_t client, lockdownd_pair_record_t pair_record, plist_t options, plist_t *response);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_pair_with_options(lockdownd_client_t client, lockdownd_pair_record_t pair_record, plist_t options, plist_t *response);
 
 /**
  * Validates if the device is paired with the given HostID. If successful the
@@ -332,7 +332,7 @@ lockdownd_error_t lockdownd_pair_with_options(lockdownd_client_t client, lockdow
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
 /**
  * Unpairs the device with the given HostID and removes the pairing records
@@ -348,7 +348,7 @@ lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_p
  *  LOCKDOWN_E_PASSWORD_PROTECTED if the device is password protected,
  *  LOCKDOWN_E_INVALID_HOST_ID if the device does not know the caller's host id
  */
-lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record);
 
 /**
  * Activates the device. Only works within an open session.
@@ -365,7 +365,7 @@ lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_rec
  *  LOCKDOWN_E_INVALID_ACTIVATION_RECORD if the device reports that the
  *  activation_record is invalid
  */
-lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record);
 
 /**
  * Deactivates the device, returning it to the locked “Activate with iTunes”
@@ -377,7 +377,7 @@ lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activati
  *  LOCKDOWN_E_NO_RUNNING_SESSION if no session is open,
  *  LOCKDOWN_E_PLIST_ERROR if the received plist is broken
  */
-lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
 
 /**
  * Tells the device to immediately enter recovery mode.
@@ -386,7 +386,7 @@ lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client);
  *
  * @return LOCKDOWN_E_SUCCESS on success, LOCKDOWN_E_INVALID_ARG when client is NULL
  */
-lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
 
 /**
  * Sends the Goodbye request to lockdownd signaling the end of communication.
@@ -397,7 +397,7 @@ lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client);
  *  is NULL, LOCKDOWN_E_PLIST_ERROR if the device did not acknowledge the
  *  request
  */
-lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
 
 /* Helper */
 
@@ -408,7 +408,7 @@ lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client);
  * @param label The label to set or NULL to disable sending a label
  *
  */
-void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
+LIBIMOBILEDEVICE_API void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
 
 /**
  * Returns the unique id of the device from lockdownd.
@@ -419,7 +419,7 @@ void lockdownd_client_set_label(lockdownd_client_t client, const char *label);
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **udid);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **udid);
 
 /**
  * Retrieves the name of the device from lockdownd set by the user.
@@ -430,7 +430,7 @@ lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **ud
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name);
 
 /**
  * Calculates and returns the data classes the device supports from lockdownd.
@@ -445,7 +445,7 @@ lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **de
  *  LOCKDOWN_E_NO_RUNNING_SESSION if no session is open,
  *  LOCKDOWN_E_PLIST_ERROR if the received plist is broken
  */
-lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count);
 
 /**
  * Frees memory of an allocated array of data classes as returned by lockdownd_get_sync_data_classes()
@@ -454,7 +454,7 @@ lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, cha
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_data_classes_free(char **classes);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classes);
 
 /**
  * Frees memory of a service descriptor as returned by lockdownd_start_service()
@@ -463,7 +463,7 @@ lockdownd_error_t lockdownd_data_classes_free(char **classes);
  *
  * @return LOCKDOWN_E_SUCCESS on success
  */
-lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service);
+LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service);
 
 /**
  * Gets a readable error string for a given lockdown error code.
@@ -472,7 +472,7 @@ lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor
  *
  * @returns A readable error string
  */
-const char* lockdownd_strerror(lockdownd_error_t err);
+LIBIMOBILEDEVICE_API const char* lockdownd_strerror(lockdownd_error_t err);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/misagent.h
+++ b/include/libimobiledevice/misagent.h
@@ -59,7 +59,7 @@ typedef misagent_client_private *misagent_client_t; /**< The client handle. */
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is NULL, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client);
 
 /**
  * Starts a new misagent service on the specified device and connects to it.
@@ -74,7 +74,7 @@ misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descrip
  * @return MISAGENT_E_SUCCESS on success, or an MISAGENT_E_* error
  *     code otherwise.
  */
-misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t* client, const char* label);
 
 /**
  * Disconnects an misagent client from the device and frees up the
@@ -85,7 +85,7 @@ misagent_error_t misagent_client_start_service(idevice_t device, misagent_client
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is NULL, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_client_free(misagent_client_t client);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_client_free(misagent_client_t client);
 
 
 /**
@@ -98,7 +98,7 @@ misagent_error_t misagent_client_free(misagent_client_t client);
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is invalid, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
 
 /**
  * Retrieves all installed provisioning profiles (iOS 9.2.1 or below).
@@ -117,7 +117,7 @@ misagent_error_t misagent_install(misagent_client_t client, plist_t profile);
  *     still returns MISAGENT_E_SUCCESS and profiles will just point to an
  *     empty array.
  */
-misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
 
 /**
  * Retrieves all installed provisioning profiles (iOS 9.3 or higher).
@@ -136,7 +136,7 @@ misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles);
  *     still returns MISAGENT_E_SUCCESS and profiles will just point to an
  *     empty array.
  */
-misagent_error_t misagent_copy_all(misagent_client_t client, plist_t* profiles);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_copy_all(misagent_client_t client, plist_t* profiles);
 
 /**
  * Removes a given provisioning profile.
@@ -149,7 +149,7 @@ misagent_error_t misagent_copy_all(misagent_client_t client, plist_t* profiles);
  * @return MISAGENT_E_SUCCESS on success, MISAGENT_E_INVALID_ARG when
  *     client is invalid, or an MISAGENT_E_* error code otherwise.
  */
-misagent_error_t misagent_remove(misagent_client_t client, const char* profileID);
+LIBIMOBILEDEVICE_API misagent_error_t misagent_remove(misagent_client_t client, const char* profileID);
 
 /**
  * Retrieves the status code from the last operation.
@@ -158,7 +158,7 @@ misagent_error_t misagent_remove(misagent_client_t client, const char* profileID
  *
  * @return -1 if client is invalid, or the status code from the last operation
  */
-int misagent_get_status_code(misagent_client_t client);
+LIBIMOBILEDEVICE_API int misagent_get_status_code(misagent_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobile_image_mounter.h
+++ b/include/libimobiledevice/mobile_image_mounter.h
@@ -65,7 +65,7 @@ typedef ssize_t (*mobile_image_mounter_upload_cb_t) (void* buffer, size_t length
  *    or MOBILE_IMAGE_MOUNTER_E_CONN_FAILED if the connection to the
  *    device could not be established.
  */
-mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client);
 
 /**
  * Starts a new mobile_image_mounter service on the specified device and connects to it.
@@ -80,7 +80,7 @@ mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdown
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success, or an MOBILE_IMAGE_MOUNTER_E_* error
  *     code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t* client, const char* label);
 
 /**
  * Disconnects a mobile_image_mounter client from the device and frees up the
@@ -91,7 +91,7 @@ mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success,
  *    or MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if client is NULL.
  */
-mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client);
 
 
 /**
@@ -107,7 +107,7 @@ mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_clie
  *
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on success, or an error code on error
  */
-mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result);
 
 /**
  * Uploads an image with an optional signature to the device.
@@ -126,7 +126,7 @@ mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_moun
  * @return MOBILE_IMAGE_MOUNTER_E_SUCCESS on succes, or a
  *    MOBILE_IMAGE_MOUNTER_E_* error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata);
 
 /**
  * Mounts an image on the device.
@@ -149,7 +149,7 @@ mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_moun
  *    MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if on ore more parameters are
  *    invalid, or another error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result);
 
 /**
  * Hangs up the connection to the mobile_image_mounter service.
@@ -162,7 +162,7 @@ mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mount
  *     MOBILE_IMAGE_MOUNTER_E_INVALID_ARG if client is invalid,
  *     or another error code otherwise.
  */
-mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client);
+LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobileactivation.h
+++ b/include/libimobiledevice/mobileactivation.h
@@ -58,7 +58,7 @@ typedef mobileactivation_client_private *mobileactivation_client_t; /**< The cli
  *     MOBILEACTIVATION_E_INVALID_ARG when one of the parameters is invalid,
  *     or MOBILEACTIVATION_E_MUX_ERROR when the connection failed.
  */
-mobileactivation_error_t mobileactivation_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobileactivation_client_t *client);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobileactivation_client_t *client);
 
 /**
  * Starts a new mobileactivation service on the specified device and connects to it.
@@ -73,7 +73,7 @@ mobileactivation_error_t mobileactivation_client_new(idevice_t device, lockdownd
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_client_start_service(idevice_t device, mobileactivation_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_start_service(idevice_t device, mobileactivation_client_t* client, const char* label);
 
 /**
  * Disconnects a mobileactivation client from the device and frees up the
@@ -86,7 +86,7 @@ mobileactivation_error_t mobileactivation_client_start_service(idevice_t device,
  *     is invalid, or MOBILEACTIVATION_E_UNKNOWN_ERROR when the was an
  *     error freeing the parent property_list_service client.
  */
-mobileactivation_error_t mobileactivation_client_free(mobileactivation_client_t client);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_free(mobileactivation_client_t client);
 
 
 /**
@@ -101,7 +101,7 @@ mobileactivation_error_t mobileactivation_client_free(mobileactivation_client_t 
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_get_activation_state(mobileactivation_client_t client, plist_t *state);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_get_activation_state(mobileactivation_client_t client, plist_t *state);
 
 /**
  * Retrieves a session blob required for 'drmHandshake' via albert.apple.com.
@@ -115,7 +115,7 @@ mobileactivation_error_t mobileactivation_get_activation_state(mobileactivation_
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_create_activation_session_info(mobileactivation_client_t client, plist_t *blob);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_session_info(mobileactivation_client_t client, plist_t *blob);
 
 /**
  * Retrieves the activation info required for device activation.
@@ -129,7 +129,7 @@ mobileactivation_error_t mobileactivation_create_activation_session_info(mobilea
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_create_activation_info(mobileactivation_client_t client, plist_t *info);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_info(mobileactivation_client_t client, plist_t *info);
 
 /**
  * Retrieves the activation info required for device activation in 'session'
@@ -147,7 +147,7 @@ mobileactivation_error_t mobileactivation_create_activation_info(mobileactivatio
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_create_activation_info_with_session(mobileactivation_client_t client, plist_t handshake_response, plist_t *info);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_info_with_session(mobileactivation_client_t client, plist_t handshake_response, plist_t *info);
 
 /**
  * Activates the device with the given activation record.
@@ -160,7 +160,7 @@ mobileactivation_error_t mobileactivation_create_activation_info_with_session(mo
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_activate(mobileactivation_client_t client, plist_t activation_record);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate(mobileactivation_client_t client, plist_t activation_record);
 
 /**
  * Activates the device with the given activation record in 'session' mode.
@@ -175,14 +175,14 @@ mobileactivation_error_t mobileactivation_activate(mobileactivation_client_t cli
  * @return MOBILEACTIVATION_E_SUCCESS on success, or an MOBILEACTIVATION_E_*
  *     error code otherwise.
  */
-mobileactivation_error_t mobileactivation_activate_with_session(mobileactivation_client_t client, plist_t activation_record, plist_t headers);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate_with_session(mobileactivation_client_t client, plist_t activation_record, plist_t headers);
 
 /**
  * Deactivates the device.
  *
  * @param client The mobileactivation client
  */
-mobileactivation_error_t mobileactivation_deactivate(mobileactivation_client_t client);
+LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_deactivate(mobileactivation_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilebackup.h
+++ b/include/libimobiledevice/mobilebackup.h
@@ -67,7 +67,7 @@ typedef enum {
  *     or more parameters are invalid, or DEVICE_LINK_SERVICE_E_BAD_VERSION if
  *     the mobilebackup version on the device is newer.
  */
-mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client);
 
 /**
  * Starts a new mobilebackup service on the specified device and connects to it.
@@ -82,7 +82,7 @@ mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service
  * @return MOBILEBACKUP_E_SUCCESS on success, or an MOBILEBACKUP_E_* error
  *     code otherwise.
  */
-mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilebackup client from the device and frees up the
@@ -93,7 +93,7 @@ mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobileb
  * @return MOBILEBACKUP_E_SUCCESS on success, or MOBILEBACKUP_E_INVALID_ARG
  *     if client is NULL.
  */
-mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
 
 
 /**
@@ -104,7 +104,7 @@ mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client);
  *
  * @return an error code
  */
-mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t *plist);
 
 /**
  * Sends mobilebackup data to the device
@@ -117,7 +117,7 @@ mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t 
  *
  * @return an error code
  */
-mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist);
 
 /**
  * Request a backup from the connected device.
@@ -136,7 +136,7 @@ mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t pli
  *    backup_manifest is not of type PLIST_DICT, MOBILEBACKUP_E_MUX_ERROR
  *    if a communication error occurs, MOBILEBACKUP_E_REPLY_NOT_OK
  */
-mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version);
 
 /**
  * Sends a confirmation to the device that a backup file has been received.
@@ -147,7 +147,7 @@ mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, p
  *    client is invalid, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client);
 
 /**
  * Request that a backup should be restored to the connected device.
@@ -170,7 +170,7 @@ mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_
  *    if a communication error occurs, or MOBILEBACKUP_E_REPLY_NOT_OK
  *    if the device did not accept the request.
  */
-mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version);
 
 /**
  * Receive a confirmation from the device that it successfully received
@@ -190,7 +190,7 @@ mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, 
  *    message plist, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result);
 
 /**
  * Receive a confirmation from the device that it successfully received
@@ -210,7 +210,7 @@ mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_cli
  *    message plist, or MOBILEBACKUP_E_MUX_ERROR if a communication error
  *    occurs.
  */
-mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result);
 
 /**
  * Tells the device that the restore process is complete and waits for the
@@ -223,7 +223,7 @@ mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebac
  *    message plist is invalid, or MOBILEBACKUP_E_MUX_ERROR if a communication
  *    error occurs.
  */
-mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client);
 
 /**
  * Sends a backup error message to the device.
@@ -235,7 +235,7 @@ mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t cl
  *    one of the parameters is invalid, or MOBILEBACKUP_E_MUX_ERROR if a
  *    communication error occurs.
  */
-mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason);
+LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilebackup2.h
+++ b/include/libimobiledevice/mobilebackup2.h
@@ -63,7 +63,7 @@ typedef mobilebackup2_client_private *mobilebackup2_client_t; /**< The client ha
  *     if one or more parameter is invalid, or MOBILEBACKUP2_E_BAD_VERSION
  *     if the mobilebackup2 version on the device is newer.
  */
-mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup2_client_t * client);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup2_client_t * client);
 
 /**
  * Starts a new mobilebackup2 service on the specified device and connects to it.
@@ -78,7 +78,7 @@ mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_servi
  * @return MOBILEBACKUP2_E_SUCCESS on success, or an MOBILEBACKUP2_E_* error
  *     code otherwise.
  */
-mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilebackup2 client from the device and frees up the
@@ -89,7 +89,7 @@ mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobil
  * @return MOBILEBACKUP2_E_SUCCESS on success, or MOBILEBACKUP2_E_INVALID_ARG
  *     if client is NULL.
  */
-mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
 
 
 /**
@@ -104,7 +104,7 @@ mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client);
  *     will be inserted into this plist before sending it. This parameter
  *     can be NULL if message is not NULL.
  */
-mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options);
 
 /**
  * Receives a DL* message plist from the device.
@@ -124,7 +124,7 @@ mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, 
  *    or is not a DL* message plist, or MOBILEBACKUP2_E_MUX_ERROR if
  *    receiving from the device failed.
  */
-mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage);
 
 /**
  * Send binary data to the device.
@@ -142,7 +142,7 @@ mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t clien
  *     MOBILEBACKUP2_E_INVALID_ARG if one of the parameters is invalid,
  *     or MOBILEBACKUP2_E_MUX_ERROR if sending of the data failed.
  */
-mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes);
 
 /**
  * Receive binary from the device.
@@ -162,7 +162,7 @@ mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, cons
  *     MOBILEBACKUP2_E_INVALID_ARG if one of the parameters is invalid,
  *     or MOBILEBACKUP2_E_MUX_ERROR if receiving the data failed.
  */
-mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes);
 
 /**
  * Performs the mobilebackup2 protocol version exchange.
@@ -175,7 +175,7 @@ mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, c
  * @return MOBILEBACKUP2_E_SUCCESS on success, or a MOBILEBACKUP2_E_* error
  *     code otherwise.
  */
-mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version);
 
 /**
  * Send a request to the connected mobilebackup2 service.
@@ -190,7 +190,7 @@ mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t clie
  * @return MOBILEBACKUP2_E_SUCCESS if the request was successfully sent,
  *     or a MOBILEBACKUP2_E_* error value otherwise.
  */
-mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options);
 
 /**
  * Sends a DLMessageStatusResponse to the device.
@@ -204,7 +204,7 @@ mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, 
  * @return MOBILEBACKUP2_E_SUCCESS on success, MOBILEBACKUP2_E_INVALID_ARG
  *     if client is invalid, or another MOBILEBACKUP2_E_* otherwise.
  */
-mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2);
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/mobilesync.h
+++ b/include/libimobiledevice/mobilesync.h
@@ -83,7 +83,7 @@ typedef mobilesync_anchors *mobilesync_anchors_t; /**< Anchors used by the devic
  * @retval DEVICE_LINK_SERVICE_E_BAD_VERSION if the mobilesync version on
  * the device is newer.
  */
-mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilesync_client_t * client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilesync_client_t * client);
 
 /**
  * Starts a new mobilesync service on the specified device and connects to it.
@@ -98,7 +98,7 @@ mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_des
  * @return MOBILESYNC_E_SUCCESS on success, or an MOBILESYNC_E_* error
  *     code otherwise.
  */
-mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t* client, const char* label);
 
 /**
  * Disconnects a mobilesync client from the device and frees up the
@@ -109,7 +109,7 @@ mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if \a client is NULL.
  */
-mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
 
 
 /**
@@ -120,7 +120,7 @@ mobilesync_error_t mobilesync_client_free(mobilesync_client_t client);
  *
  * @return an error code
  */
-mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist);
 
 /**
  * Sends mobilesync data to the device
@@ -133,7 +133,7 @@ mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t *plist
  *
  * @return an error code
  */
-mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
 
 
 /**
@@ -156,7 +156,7 @@ mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist);
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * sync request
  */
-mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description);
 
 /**
  * Cancels a running synchronization session with a device at any time.
@@ -167,7 +167,7 @@ mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason);
 
 /**
  * Finish a synchronization session of a data class on the device.
@@ -180,7 +180,7 @@ mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* rea
  * @retval MOBILESYNC_E_PLIST_ERROR if the received plist is not of valid
  * form
  */
-mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
 
 
 /**
@@ -193,7 +193,7 @@ mobilesync_error_t mobilesync_finish(mobilesync_client_t client);
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client);
 
 /**
  * Requests to receive only changed records of the currently set data class from the device.
@@ -205,7 +205,7 @@ mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t cl
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client);
 
 /**
  * Requests the device to delete all records of the current data class
@@ -218,7 +218,7 @@ mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  * @retval MOBILESYNC_E_PLIST_ERROR if the received plist is not of valid form
  */
-mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client);
 
 
 /**
@@ -234,7 +234,7 @@ mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t cl
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * session
  */
-mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions);
 
 /**
  * Acknowledges to the device that the changes have been merged on the computer
@@ -244,7 +244,7 @@ mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_
  * @retval MOBILESYNC_E_SUCCESS on success
  * @retval MOBILESYNC_E_INVALID_ARG if one of the parameters is invalid
  */
-mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client);
 
 
 /**
@@ -264,7 +264,7 @@ mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_
  * @retval MOBILESYNC_E_NOT_READY if the device is not ready to start
  * receiving any changes
  */
-mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client);
 
 
 /**
@@ -281,7 +281,7 @@ mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_cli
  * @retval MOBILESYNC_E_WRONG_DIRECTION if the current sync direction does
  * not permit this call
  */
-mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions);
 
 /**
  * Receives any remapped identifiers reported after the device merged submitted changes.
@@ -298,7 +298,7 @@ mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t e
  * @retval MOBILESYNC_E_CANCELLED if the device explicitly cancelled the
  * session
  */
-mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping);
+LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping);
 
 /* Helper */
 
@@ -311,14 +311,14 @@ mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plis
  *
  * @return A new #mobilesync_anchors_t struct. Must be freed using mobilesync_anchors_free().
  */
-mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor);
+LIBIMOBILEDEVICE_API mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor);
 
 /**
  * Free memory used by anchors.
  *
  * @param anchors The anchors to free.
  */
-void mobilesync_anchors_free(mobilesync_anchors_t anchors);
+LIBIMOBILEDEVICE_API void mobilesync_anchors_free(mobilesync_anchors_t anchors);
 
 
 /**
@@ -326,7 +326,7 @@ void mobilesync_anchors_free(mobilesync_anchors_t anchors);
  *
  * @return A new plist_t of type PLIST_DICT.
  */
-plist_t mobilesync_actions_new(void);
+LIBIMOBILEDEVICE_API plist_t mobilesync_actions_new(void);
 
 /**
  * Add one or more new key:value pairs to the given actions plist.
@@ -340,14 +340,14 @@ plist_t mobilesync_actions_new(void);
  *       integer to use as a boolean value indicating that the device should
  *       link submitted changes and report remapped identifiers.
  */
-void mobilesync_actions_add(plist_t actions, ...);
+LIBIMOBILEDEVICE_API void mobilesync_actions_add(plist_t actions, ...);
 
 /**
  * Free actions plist.
  *
  * @param actions The actions plist to free. Does nothing if NULL is passed.
  */
-void mobilesync_actions_free(plist_t actions);
+LIBIMOBILEDEVICE_API void mobilesync_actions_free(plist_t actions);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/notification_proxy.h
+++ b/include/libimobiledevice/notification_proxy.h
@@ -103,7 +103,7 @@ typedef void (*np_notify_cb_t) (const char *notification, void *user_data);
  *   or NP_E_CONN_FAILED when the connection to the device could not be
  *   established.
  */
-np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client);
+LIBIMOBILEDEVICE_API np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client);
 
 /**
  * Starts a new notification proxy service on the specified device and connects to it.
@@ -118,7 +118,7 @@ np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t servic
  * @return NP_E_SUCCESS on success, or an NP_E_* error
  *     code otherwise.
  */
-np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label);
 
 /**
  * Disconnects a notification_proxy client from the device and frees up the
@@ -128,7 +128,7 @@ np_error_t np_client_start_service(idevice_t device, np_client_t* client, const 
  *
  * @return NP_E_SUCCESS on success, or NP_E_INVALID_ARG when client is NULL.
  */
-np_error_t np_client_free(np_client_t client);
+LIBIMOBILEDEVICE_API np_error_t np_client_free(np_client_t client);
 
 
 /**
@@ -139,7 +139,7 @@ np_error_t np_client_free(np_client_t client);
  *
  * @return NP_E_SUCCESS on success, or an error returned by np_plist_send
  */
-np_error_t np_post_notification(np_client_t client, const char *notification);
+LIBIMOBILEDEVICE_API np_error_t np_post_notification(np_client_t client, const char *notification);
 
 /**
  * Tells the device to send a notification on the specified event.
@@ -150,7 +150,7 @@ np_error_t np_post_notification(np_client_t client, const char *notification);
  * @return NP_E_SUCCESS on success, NP_E_INVALID_ARG when client or
  *    notification are NULL, or an error returned by np_plist_send.
  */
-np_error_t np_observe_notification(np_client_t client, const char *notification);
+LIBIMOBILEDEVICE_API np_error_t np_observe_notification(np_client_t client, const char *notification);
 
 /**
  * Tells the device to send a notification on specified events.
@@ -163,7 +163,7 @@ np_error_t np_observe_notification(np_client_t client, const char *notification)
  * @return NP_E_SUCCESS on success, NP_E_INVALID_ARG when client is null,
  *   or an error returned by np_observe_notification.
  */
-np_error_t np_observe_notifications(np_client_t client, const char **notification_spec);
+LIBIMOBILEDEVICE_API np_error_t np_observe_notifications(np_client_t client, const char **notification_spec);
 
 /**
  * This function allows an application to define a callback function that will
@@ -187,7 +187,7 @@ np_error_t np_observe_notifications(np_client_t client, const char **notificatio
  *         NP_E_INVALID_ARG when client is NULL, or NP_E_UNKNOWN_ERROR when
  *         the callback thread could no be created.
  */
-np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *userdata);
+LIBIMOBILEDEVICE_API np_error_t np_set_notify_callback(np_client_t client, np_notify_cb_t notify_cb, void *userdata);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/preboard.h
+++ b/include/libimobiledevice/preboard.h
@@ -63,7 +63,7 @@ typedef void (*preboard_status_cb_t) (plist_t message, void *user_data);
  * @return PREBOARD_E_SUCCESS on success, PREBOARD_E_INVALID_ARG when
  *     client is NULL, or an PREBOARD_E_* error code otherwise.
  */
-preboard_error_t preboard_client_new(idevice_t device, lockdownd_service_descriptor_t service, preboard_client_t * client);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_client_new(idevice_t device, lockdownd_service_descriptor_t service, preboard_client_t * client);
 
 /**
  * Starts a new preboard service on the specified device and connects to it.
@@ -78,7 +78,7 @@ preboard_error_t preboard_client_new(idevice_t device, lockdownd_service_descrip
  * @return PREBOARD_E_SUCCESS on success, or a PREBOARD_E_* error
  *     code otherwise.
  */
-preboard_error_t preboard_client_start_service(idevice_t device, preboard_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_client_start_service(idevice_t device, preboard_client_t * client, const char* label);
 
 /**
  * Disconnects a preboard client from the device and frees up the
@@ -89,7 +89,7 @@ preboard_error_t preboard_client_start_service(idevice_t device, preboard_client
  * @return PREBOARD_E_SUCCESS on success, PREBOARD_E_INVALID_ARG when
  *     client is NULL, or a PREBOARD_E_* error code otherwise.
  */
-preboard_error_t preboard_client_free(preboard_client_t client);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_client_free(preboard_client_t client);
 
 /**
  * Sends a plist to the service.
@@ -101,7 +101,7 @@ preboard_error_t preboard_client_free(preboard_client_t client);
  *  PREBOARD_E_INVALID_ARG when client or plist is NULL,
  *  or a PREBOARD_E_* error code on error
  */
-preboard_error_t preboard_send(preboard_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_send(preboard_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -114,7 +114,7 @@ preboard_error_t preboard_send(preboard_client_t client, plist_t plist);
  *  PREBOARD_E_TIMEOUT when no data was received after 5 seconds,
  *  or a PREBOARD_E_* error code on error
  */
-preboard_error_t preboard_receive(preboard_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_receive(preboard_client_t client, plist_t * plist);
 
 /**
  * Receives a plist from the service with the specified timeout.
@@ -127,7 +127,7 @@ preboard_error_t preboard_receive(preboard_client_t client, plist_t * plist);
  *  PREBOARD_E_TIMEOUT when no data was received after the given timeout,
  *  or a PREBOARD_E_* error code on error.
  */
-preboard_error_t preboard_receive_with_timeout(preboard_client_t client, plist_t * plist, uint32_t timeout_ms);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_receive_with_timeout(preboard_client_t client, plist_t * plist, uint32_t timeout_ms);
 
 /**
  * Tells the preboard service to create a stashbag. This will make the device
@@ -155,7 +155,7 @@ preboard_error_t preboard_receive_with_timeout(preboard_client_t client, plist_t
  *  PREBOARD_E_INVALID_ARG when client is invalid,
  *  or a PREBOARD_E_* error code on error.
  */
-preboard_error_t preboard_create_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_create_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data);
 
 /**
  * Instructs the preboard service to commit a previously created stashbag.
@@ -176,7 +176,7 @@ preboard_error_t preboard_create_stashbag(preboard_client_t client, plist_t mani
  *  PREBOARD_E_INVALID_ARG when client is invalid,
  *  or a PREBOARD_E_* error code on error.
  */
-preboard_error_t preboard_commit_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data);
+LIBIMOBILEDEVICE_API preboard_error_t preboard_commit_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/property_list_service.h
+++ b/include/libimobiledevice/property_list_service.h
@@ -59,7 +59,7 @@ typedef property_list_service_private* property_list_service_client_t; /**< The 
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG when one of the arguments is invalid,
  *     or PROPERTY_LIST_SERVICE_E_MUX_ERROR when connecting to the device failed.
  */
-property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client);
 
 /**
  * Frees a PropertyList service.
@@ -70,7 +70,7 @@ property_list_service_error_t property_list_service_client_new(idevice_t device,
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG when client is invalid, or a
  *     PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when another error occurred.
  */
-property_list_service_error_t property_list_service_client_free(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_free(property_list_service_client_t client);
 
 /**
  * Sends an XML plist.
@@ -83,7 +83,7 @@ property_list_service_error_t property_list_service_client_free(property_list_se
  *      PROPERTY_LIST_SERVICE_E_PLIST_ERROR when dict is not a valid plist,
  *      or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist);
 
 /**
  * Sends a binary plist.
@@ -96,7 +96,7 @@ property_list_service_error_t property_list_service_send_xml_plist(property_list
  *      PROPERTY_LIST_SERVICE_E_PLIST_ERROR when dict is not a valid plist,
  *      or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist);
 
 /**
  * Receives a plist using the given property list service client with specified
@@ -115,7 +115,7 @@ property_list_service_error_t property_list_service_send_binary_plist(property_l
  *      communication error occurs, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when
  *      an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout);
 
 /**
  * Receives a plist using the given property list service client.
@@ -138,7 +138,7 @@ property_list_service_error_t property_list_service_receive_plist_with_timeout(p
  *      communication error occurs, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR when
  *      an unspecified error occurs.
  */
-property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist);
 
 /**
  * Enable SSL for the given property list service client.
@@ -151,7 +151,7 @@ property_list_service_error_t property_list_service_receive_plist(property_list_
  *     NULL, PROPERTY_LIST_SERVICE_E_SSL_ERROR when SSL could not be enabled,
  *     or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client);
 
 /**
  * Disable SSL for the given property list service client.
@@ -163,7 +163,7 @@ property_list_service_error_t property_list_service_enable_ssl(property_list_ser
  *     PROPERTY_LIST_SERVICE_E_INVALID_ARG if client or client->connection is
  *     NULL, or PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client);
+LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/restore.h
+++ b/include/libimobiledevice/restore.h
@@ -56,7 +56,7 @@ typedef restored_client_private *restored_client_t; /**< The client handle. */
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label);
+LIBIMOBILEDEVICE_API restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label);
 
 /**
  * Closes the restored client session if one is running and frees up the
@@ -66,7 +66,7 @@ restored_error_t restored_client_new(idevice_t device, restored_client_t *client
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_client_free(restored_client_t client);
+LIBIMOBILEDEVICE_API restored_error_t restored_client_free(restored_client_t client);
 
 
 /**
@@ -79,7 +79,7 @@ restored_error_t restored_client_free(restored_client_t client);
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL
  */
-restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version);
+LIBIMOBILEDEVICE_API restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version);
 
 /**
  * Queries a value from the device specified by a key.
@@ -90,7 +90,7 @@ restored_error_t restored_query_type(restored_client_t client, char **type, uint
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL, RESTORE_E_PLIST_ERROR if value for key can't be found
  */
-restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value);
+LIBIMOBILEDEVICE_API restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value);
 
 /**
  * Retrieves a value from information plist specified by a key.
@@ -101,7 +101,7 @@ restored_error_t restored_query_value(restored_client_t client, const char *key,
  *
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL, RESTORE_E_PLIST_ERROR if value for key can't be found
  */
-restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value) ;
+LIBIMOBILEDEVICE_API restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value) ;
 
 /**
  * Sends a plist to restored.
@@ -115,7 +115,7 @@ restored_error_t restored_get_value(restored_client_t client, const char *key, p
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client or
  *  plist is NULL
  */
-restored_error_t restored_send(restored_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API restored_error_t restored_send(restored_client_t client, plist_t plist);
 
 /**
  * Receives a plist from restored.
@@ -126,7 +126,7 @@ restored_error_t restored_send(restored_client_t client, plist_t plist);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client or
  *  plist is NULL
  */
-restored_error_t restored_receive(restored_client_t client, plist_t *plist);
+LIBIMOBILEDEVICE_API restored_error_t restored_receive(restored_client_t client, plist_t *plist);
 
 /**
  * Sends the Goodbye request to restored signaling the end of communication.
@@ -136,7 +136,7 @@ restored_error_t restored_receive(restored_client_t client, plist_t *plist);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG when client is NULL,
  *  RESTORE_E_PLIST_ERROR if the device did not acknowledge the request
  */
-restored_error_t restored_goodbye(restored_client_t client);
+LIBIMOBILEDEVICE_API restored_error_t restored_goodbye(restored_client_t client);
 
 
 /**
@@ -149,7 +149,7 @@ restored_error_t restored_goodbye(restored_client_t client);
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG if a parameter
  *  is NULL, RESTORE_E_START_RESTORE_FAILED if the request fails
  */
-restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version);
+LIBIMOBILEDEVICE_API restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version);
 
 /**
  * Requests device to reboot.
@@ -159,7 +159,7 @@ restored_error_t restored_start_restore(restored_client_t client, plist_t option
  * @return RESTORE_E_SUCCESS on success, RESTORE_E_INVALID_ARG if a parameter
  *  is NULL
  */
-restored_error_t restored_reboot(restored_client_t client);
+LIBIMOBILEDEVICE_API restored_error_t restored_reboot(restored_client_t client);
 
 /* Helper */
 
@@ -170,7 +170,7 @@ restored_error_t restored_reboot(restored_client_t client);
  * @param label The label to set or NULL to disable sending a label
  *
  */
-void restored_client_set_label(restored_client_t client, const char *label);
+LIBIMOBILEDEVICE_API void restored_client_set_label(restored_client_t client, const char *label);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/sbservices.h
+++ b/include/libimobiledevice/sbservices.h
@@ -69,7 +69,7 @@ typedef sbservices_client_private *sbservices_client_t; /**< The client handle. 
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client);
 
 /**
  * Starts a new sbservices service on the specified device and connects to it.
@@ -84,7 +84,7 @@ sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_des
  * @return SBSERVICES_E_SUCCESS on success, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t* client, const char* label);
 
 /**
  * Disconnects an sbservices client from the device and frees up the
@@ -95,7 +95,7 @@ sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_client_free(sbservices_client_t client);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_free(sbservices_client_t client);
 
 
 /**
@@ -112,7 +112,7 @@ sbservices_error_t sbservices_client_free(sbservices_client_t client);
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or state is invalid, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version);
 
 /**
  * Sets the icon state of the connected device.
@@ -123,7 +123,7 @@ sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or newstate is NULL, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate);
 
 /**
  * Get the icon of the specified app as PNG data.
@@ -140,7 +140,7 @@ sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t
  *     client, bundleId, or pngdata are invalid, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize);
 
 /**
  * Gets the interface orientation of the device.
@@ -151,7 +151,7 @@ sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const
  * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
  *     client or state is invalid, or an SBSERVICES_E_* error code otherwise.
  */
-sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation);
 
 /**
  * Get the home screen wallpaper as PNG data.
@@ -167,7 +167,7 @@ sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t clie
  *     client or pngdata are invalid, or an SBSERVICES_E_* error
  *     code otherwise.
  */
-sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/screenshotr.h
+++ b/include/libimobiledevice/screenshotr.h
@@ -65,7 +65,7 @@ typedef screenshotr_client_private *screenshotr_client_t; /**< The client handle
  *     or more parameters are invalid, or SCREENSHOTR_E_CONN_FAILED if the
  *     connection to the device could not be established.
  */
-screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service, screenshotr_client_t * client);
+LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service, screenshotr_client_t * client);
 
 /**
  * Starts a new screenshotr service on the specified device and connects to it.
@@ -80,7 +80,7 @@ screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_d
  * @return SCREENSHOTR_E_SUCCESS on success, or an SCREENSHOTR_E_* error
  *     code otherwise.
  */
-screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t* client, const char* label);
+LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t* client, const char* label);
 
 /**
  * Disconnects a screenshotr client from the device and frees up the
@@ -91,7 +91,7 @@ screenshotr_error_t screenshotr_client_start_service(idevice_t device, screensho
  * @return SCREENSHOTR_E_SUCCESS on success, or SCREENSHOTR_E_INVALID_ARG
  *     if client is NULL.
  */
-screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
+LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
 
 
 /**
@@ -108,7 +108,7 @@ screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
  *     one or more parameters are invalid, or another error code if an
  *     error occurred.
  */
-screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
+LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/service.h
+++ b/include/libimobiledevice/service.h
@@ -61,7 +61,7 @@ typedef service_client_private* service_client_t; /**< The client handle. */
  *     SERVICE_E_INVALID_ARG when one of the arguments is invalid,
  *     or SERVICE_E_MUX_ERROR when connecting to the device failed.
  */
-service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client);
+LIBIMOBILEDEVICE_API service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client);
 
 /**
  * Starts a new service on the specified device with given name and
@@ -78,7 +78,7 @@ service_error_t service_client_new(idevice_t device, lockdownd_service_descripto
  * @return SERVICE_E_SUCCESS on success, or a SERVICE_E_* error code
  *     otherwise.
  */
-service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code);
+LIBIMOBILEDEVICE_API service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code);
 
 /**
  * Frees a service instance.
@@ -89,7 +89,7 @@ service_error_t service_client_factory_start_service(idevice_t device, const cha
  *     SERVICE_E_INVALID_ARG when client is invalid, or a
  *     SERVICE_E_UNKNOWN_ERROR when another error occurred.
  */
-service_error_t service_client_free(service_client_t client);
+LIBIMOBILEDEVICE_API service_error_t service_client_free(service_client_t client);
 
 
 /**
@@ -105,7 +105,7 @@ service_error_t service_client_free(service_client_t client);
  *      invalid, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_send(service_client_t client, const char *data, uint32_t size, uint32_t *sent);
+LIBIMOBILEDEVICE_API service_error_t service_send(service_client_t client, const char *data, uint32_t size, uint32_t *sent);
 
 /**
  * Receives data using the given service client with specified timeout.
@@ -122,7 +122,7 @@ service_error_t service_send(service_client_t client, const char *data, uint32_t
  *      occurs, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_receive_with_timeout(service_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API service_error_t service_receive_with_timeout(service_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives data using the given service client.
@@ -140,7 +140,7 @@ service_error_t service_receive_with_timeout(service_client_t client, char *data
  *      occurs, or SERVICE_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-service_error_t service_receive(service_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API service_error_t service_receive(service_client_t client, char *data, uint32_t size, uint32_t *received);
 
 
 /**
@@ -155,7 +155,7 @@ service_error_t service_receive(service_client_t client, char *data, uint32_t si
  *     SERVICE_E_SSL_ERROR when SSL could not be enabled,
  *     or SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-service_error_t service_enable_ssl(service_client_t client);
+LIBIMOBILEDEVICE_API service_error_t service_enable_ssl(service_client_t client);
 
 /**
  * Disable SSL for the given service client.
@@ -166,7 +166,7 @@ service_error_t service_enable_ssl(service_client_t client);
  *     SERVICE_E_INVALID_ARG if client or client->connection is
  *     NULL, or SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-service_error_t service_disable_ssl(service_client_t client);
+LIBIMOBILEDEVICE_API service_error_t service_disable_ssl(service_client_t client);
 
 /**
  * Disable SSL for the given service client without sending SSL terminate messages.
@@ -177,7 +177,7 @@ service_error_t service_disable_ssl(service_client_t client);
  *     SERVICE_E_INVALID_ARG if client or client->connection is
  *     NULL, or SERVICE_E_UNKNOWN_ERROR otherwise.
  */
-service_error_t service_disable_bypass_ssl(service_client_t client, uint8_t sslBypass);
+LIBIMOBILEDEVICE_API service_error_t service_disable_bypass_ssl(service_client_t client, uint8_t sslBypass);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/syslog_relay.h
+++ b/include/libimobiledevice/syslog_relay.h
@@ -64,7 +64,7 @@ typedef void (*syslog_relay_receive_cb_t)(char c, void *user_data);
  * @return SYSLOG_RELAY_E_SUCCESS on success, SYSLOG_RELAY_E_INVALID_ARG when
  *     client is NULL, or an SYSLOG_RELAY_E_* error code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client);
 
 /**
  * Starts a new syslog_relay service on the specified device and connects to it.
@@ -79,7 +79,7 @@ syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service
  * @return SYSLOG_RELAY_E_SUCCESS on success, or an SYSLOG_RELAY_E_* error
  *     code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label);
 
 /**
  * Disconnects a syslog_relay client from the device and frees up the
@@ -90,7 +90,7 @@ syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_
  * @return SYSLOG_RELAY_E_SUCCESS on success, SYSLOG_RELAY_E_INVALID_ARG when
  *     client is NULL, or an SYSLOG_RELAY_E_* error code otherwise.
  */
-syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
 
 
 /**
@@ -107,7 +107,7 @@ syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client);
  *      invalid or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs or a syslog capture has already been started.
  */
-syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
 
 /**
  * Starts capturing the *raw* syslog of the device using a callback.
@@ -128,7 +128,7 @@ syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, sy
  *      invalid or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs or a syslog capture has already been started.
  */
-syslog_relay_error_t syslog_relay_start_capture_raw(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture_raw(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data);
 
 /**
  * Stops capturing the syslog of the device.
@@ -142,7 +142,7 @@ syslog_relay_error_t syslog_relay_start_capture_raw(syslog_relay_client_t client
  *      invalid or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs or a syslog capture has already been started.
  */
-syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
 
 /* Receiving */
 
@@ -161,7 +161,7 @@ syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client);
  *      occurs, or SYSLOG_RELAY_E_UNKNOWN_ERROR when an unspecified
  *      error occurs.
  */
-syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received, unsigned int timeout);
 
 /**
  * Receives data from the service.
@@ -175,7 +175,7 @@ syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t cli
  * @return SYSLOG_RELAY_E_SUCCESS on success,
  *  SYSLOG_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received);
+LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char *data, uint32_t size, uint32_t *received);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/webinspector.h
+++ b/include/libimobiledevice/webinspector.h
@@ -61,7 +61,7 @@ typedef webinspector_client_private *webinspector_client_t; /**< The client hand
  * @return WEBINSPECTOR_E_SUCCESS on success, WEBINSPECTOR_E_INVALID_ARG when
  *     client is NULL, or an WEBINSPECTOR_E_* error code otherwise.
  */
-webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client);
 
 /**
  * Starts a new webinspector service on the specified device and connects to it.
@@ -76,7 +76,7 @@ webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service
  * @return WEBINSPECTOR_E_SUCCESS on success, or an WEBINSPECTOR_E_* error
  *     code otherwise.
  */
-webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label);
 
 /**
  * Disconnects a webinspector client from the device and frees up the
@@ -87,7 +87,7 @@ webinspector_error_t webinspector_client_start_service(idevice_t device, webinsp
  * @return WEBINSPECTOR_E_SUCCESS on success, WEBINSPECTOR_E_INVALID_ARG when
  *     client is NULL, or an WEBINSPECTOR_E_* error code otherwise.
  */
-webinspector_error_t webinspector_client_free(webinspector_client_t client);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_free(webinspector_client_t client);
 
 
 /**
@@ -99,7 +99,7 @@ webinspector_error_t webinspector_client_free(webinspector_client_t client);
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success,
  *  DIAGNOSTICS_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist);
 
 /**
  * Receives a plist from the service.
@@ -110,7 +110,7 @@ webinspector_error_t webinspector_send(webinspector_client_t client, plist_t pli
  * @return DIAGNOSTICS_RELAY_E_SUCCESS on success,
  *  DIAGNOSTICS_RELAY_E_INVALID_ARG when client or plist is NULL
  */
-webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist);
 
 /**
  * Receives a plist using the given webinspector client.
@@ -127,7 +127,7 @@ webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t 
  *      communication error occurs, or WEBINSPECTOR_E_UNKNOWN_ERROR
  *      when an unspecified error occurs.
  */
-webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms);
+LIBIMOBILEDEVICE_API webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/src/afc.c
+++ b/src/afc.c
@@ -68,7 +68,7 @@ static void afc_unlock(afc_client_t client)
  *  invalid, or AFC_E_NO_MEM if there is a memory allocation problem.
  */
 
-LIBIMOBILEDEVICE_API afc_error_t afc_client_new_with_service_client(service_client_t service_client, afc_client_t *client)
+afc_error_t afc_client_new_with_service_client(service_client_t service_client, afc_client_t *client)
 {
 	if (!service_client)
 		return AFC_E_INVALID_ARG;
@@ -94,7 +94,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_client_new_with_service_client(service_clie
 	return AFC_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t * client)
+afc_error_t afc_client_new(idevice_t device, lockdownd_service_descriptor_t service, afc_client_t * client)
 {
 	if (!device || !service || service->port == 0)
 		return AFC_E_INVALID_ARG;
@@ -113,14 +113,14 @@ LIBIMOBILEDEVICE_API afc_error_t afc_client_new(idevice_t device, lockdownd_serv
 	return err;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_client_start_service(idevice_t device, afc_client_t * client, const char* label)
+afc_error_t afc_client_start_service(idevice_t device, afc_client_t * client, const char* label)
 {
 	afc_error_t err = AFC_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, AFC_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(afc_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_client_free(afc_client_t client)
+afc_error_t afc_client_free(afc_client_t client)
 {
 	if (!client || !client->afc_packet)
 		return AFC_E_INVALID_ARG;
@@ -410,7 +410,7 @@ static int _afc_check_packet_buffer(afc_client_t client, uint32_t data_len)
 
 #define AFC_PACKET_DATA_PTR ((char*)client->afc_packet + sizeof(AFCPacket))
 
-LIBIMOBILEDEVICE_API afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information)
+afc_error_t afc_read_directory(afc_client_t client, const char *path, char ***directory_information)
 {
 	uint32_t bytes = 0;
 	char *data = NULL, **list_loc = NULL;
@@ -454,7 +454,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_read_directory(afc_client_t client, const c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info(afc_client_t client, char ***device_information)
+afc_error_t afc_get_device_info(afc_client_t client, char ***device_information)
 {
 	uint32_t bytes = 0;
 	char *data = NULL, **list = NULL;
@@ -491,7 +491,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info(afc_client_t client, char *
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value)
+afc_error_t afc_get_device_info_key(afc_client_t client, const char *key, char **value)
 {
 	afc_error_t ret = AFC_E_INTERNAL_ERROR;
 	char **kvps, **ptr;
@@ -518,7 +518,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_get_device_info_key(afc_client_t client, co
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_remove_path(afc_client_t client, const char *path)
+afc_error_t afc_remove_path(afc_client_t client, const char *path)
 {
 	uint32_t bytes = 0;
 	afc_error_t ret = AFC_E_UNKNOWN_ERROR;
@@ -554,7 +554,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_remove_path(afc_client_t client, const char
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to)
+afc_error_t afc_rename_path(afc_client_t client, const char *from, const char *to)
 {
 	if (!client || !from || !to || !client->afc_packet || !client->parent)
 		return AFC_E_INVALID_ARG;
@@ -590,7 +590,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_rename_path(afc_client_t client, const char
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_make_directory(afc_client_t client, const char *path)
+afc_error_t afc_make_directory(afc_client_t client, const char *path)
 {
 	uint32_t bytes = 0;
 	afc_error_t ret = AFC_E_UNKNOWN_ERROR;
@@ -622,7 +622,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_make_directory(afc_client_t client, const c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_get_file_info(afc_client_t client, const char *path, char ***file_information)
+afc_error_t afc_get_file_info(afc_client_t client, const char *path, char ***file_information)
 {
 	char *received = NULL;
 	uint32_t bytes = 0;
@@ -662,7 +662,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_get_file_info(afc_client_t client, const ch
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle)
+afc_error_t afc_file_open(afc_client_t client, const char *filename, afc_file_mode_t file_mode, uint64_t *handle)
 {
 	if (!client || !client->parent || !client->afc_packet)
 		return AFC_E_INVALID_ARG;
@@ -714,7 +714,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_open(afc_client_t client, const char *
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read)
+afc_error_t afc_file_read(afc_client_t client, uint64_t handle, char *data, uint32_t length, uint32_t *bytes_read)
 {
 	char *input = NULL;
 	uint32_t current_count = 0, bytes_loc = 0;
@@ -769,7 +769,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_read(afc_client_t client, uint64_t han
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written)
+afc_error_t afc_file_write(afc_client_t client, uint64_t handle, const char *data, uint32_t length, uint32_t *bytes_written)
 {
 	uint32_t current_count = 0;
 	uint32_t bytes_loc = 0;
@@ -804,7 +804,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_write(afc_client_t client, uint64_t ha
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_close(afc_client_t client, uint64_t handle)
+afc_error_t afc_file_close(afc_client_t client, uint64_t handle)
 {
 	uint32_t bytes = 0;
 	afc_error_t ret = AFC_E_UNKNOWN_ERROR;
@@ -835,7 +835,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_close(afc_client_t client, uint64_t ha
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation)
+afc_error_t afc_file_lock(afc_client_t client, uint64_t handle, afc_lock_op_t operation)
 {
 	uint32_t bytes = 0;
 	struct lockinfo {
@@ -869,7 +869,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_lock(afc_client_t client, uint64_t han
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence)
+afc_error_t afc_file_seek(afc_client_t client, uint64_t handle, int64_t offset, int whence)
 {
 	uint32_t bytes = 0;
 	struct seekinfo {
@@ -903,7 +903,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_seek(afc_client_t client, uint64_t han
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position)
+afc_error_t afc_file_tell(afc_client_t client, uint64_t handle, uint64_t *position)
 {
 	char *buffer = NULL;
 	uint32_t bytes = 0;
@@ -938,7 +938,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_tell(afc_client_t client, uint64_t han
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize)
+afc_error_t afc_file_truncate(afc_client_t client, uint64_t handle, uint64_t newsize)
 {
 	uint32_t bytes = 0;
 	struct truncinfo {
@@ -970,7 +970,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_file_truncate(afc_client_t client, uint64_t
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize)
+afc_error_t afc_truncate(afc_client_t client, const char *path, uint64_t newsize)
 {
 	if (!client || !path || !client->afc_packet || !client->parent)
 		return AFC_E_INVALID_ARG;
@@ -1003,7 +1003,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_truncate(afc_client_t client, const char *p
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname)
+afc_error_t afc_make_link(afc_client_t client, afc_link_type_t linktype, const char *target, const char *linkname)
 {
 	if (!client || !target || !linkname || !client->afc_packet || !client->parent)
 		return AFC_E_INVALID_ARG;
@@ -1045,7 +1045,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_make_link(afc_client_t client, afc_link_typ
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime)
+afc_error_t afc_set_file_time(afc_client_t client, const char *path, uint64_t mtime)
 {
 	if (!client || !path || !client->afc_packet || !client->parent)
 		return AFC_E_INVALID_ARG;
@@ -1078,7 +1078,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_set_file_time(afc_client_t client, const ch
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path)
+afc_error_t afc_remove_path_and_contents(afc_client_t client, const char *path)
 {
 	uint32_t bytes = 0;
 	afc_error_t ret = AFC_E_UNKNOWN_ERROR;
@@ -1110,7 +1110,7 @@ LIBIMOBILEDEVICE_API afc_error_t afc_remove_path_and_contents(afc_client_t clien
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_dictionary_free(char **dictionary)
+afc_error_t afc_dictionary_free(char **dictionary)
 {
 	int i = 0;
 

--- a/src/companion_proxy.c
+++ b/src/companion_proxy.c
@@ -63,7 +63,7 @@ static companion_proxy_error_t companion_proxy_error(property_list_service_error
 	return COMPANION_PROXY_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, companion_proxy_client_t * client)
+companion_proxy_error_t companion_proxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, companion_proxy_client_t * client)
 {
 	*client = NULL;
 
@@ -91,14 +91,14 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_new(idevice_
 	return COMPANION_PROXY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_start_service(idevice_t device, companion_proxy_client_t * client, const char* label)
+companion_proxy_error_t companion_proxy_client_start_service(idevice_t device, companion_proxy_client_t * client, const char* label)
 {
 	companion_proxy_error_t err = COMPANION_PROXY_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, COMPANION_PROXY_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(companion_proxy_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_free(companion_proxy_client_t client)
+companion_proxy_error_t companion_proxy_client_free(companion_proxy_client_t client)
 {
 	if (!client)
 		return COMPANION_PROXY_E_INVALID_ARG;
@@ -117,7 +117,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_client_free(compani
 	return err;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_send(companion_proxy_client_t client, plist_t plist)
+companion_proxy_error_t companion_proxy_send(companion_proxy_client_t client, plist_t plist)
 {
 	companion_proxy_error_t res = COMPANION_PROXY_E_UNKNOWN_ERROR;
 
@@ -130,7 +130,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_send(companion_prox
 	return res;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_receive(companion_proxy_client_t client, plist_t * plist)
+companion_proxy_error_t companion_proxy_receive(companion_proxy_client_t client, plist_t * plist)
 {
 	companion_proxy_error_t res = COMPANION_PROXY_E_UNKNOWN_ERROR;
 	plist_t outplist = NULL;
@@ -144,7 +144,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_receive(companion_p
 	return res;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_get_device_registry(companion_proxy_client_t client, plist_t* paired_devices)
+companion_proxy_error_t companion_proxy_get_device_registry(companion_proxy_client_t client, plist_t* paired_devices)
 {
 	if (!client || !paired_devices) {
 		return COMPANION_PROXY_E_INVALID_ARG;
@@ -227,7 +227,7 @@ static void* companion_proxy_event_thread(void* arg)
 	return NULL;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_listening_for_devices(companion_proxy_client_t client, companion_proxy_device_event_cb_t callback, void* userdata)
+companion_proxy_error_t companion_proxy_start_listening_for_devices(companion_proxy_client_t client, companion_proxy_device_event_cb_t callback, void* userdata)
 {
 	if (!client || !client->parent || !callback) {
 		return COMPANION_PROXY_E_INVALID_ARG;
@@ -253,7 +253,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_listening_for
 	return res;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_stop_listening_for_devices(companion_proxy_client_t client)
+companion_proxy_error_t companion_proxy_stop_listening_for_devices(companion_proxy_client_t client)
 {
 	property_list_service_client_t parent = client->parent;
 	client->parent = NULL;
@@ -267,7 +267,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_stop_listening_for_
 	return COMPANION_PROXY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_get_value_from_registry(companion_proxy_client_t client, const char* companion_udid, const char* key, plist_t* value)
+companion_proxy_error_t companion_proxy_get_value_from_registry(companion_proxy_client_t client, const char* companion_udid, const char* key, plist_t* value)
 {
 	if (!client || !companion_udid || !key || !value) {
 		return COMPANION_PROXY_E_INVALID_ARG;
@@ -311,7 +311,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_get_value_from_regi
 	return res;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port, const char* service_name, uint16_t* forward_port, plist_t options)
+companion_proxy_error_t companion_proxy_start_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port, const char* service_name, uint16_t* forward_port, plist_t options)
 {
 	if (!client) {
 		return COMPANION_PROXY_E_INVALID_ARG;
@@ -354,7 +354,7 @@ LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_start_forwarding_se
 	return res;
 }
 
-LIBIMOBILEDEVICE_API companion_proxy_error_t companion_proxy_stop_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port)
+companion_proxy_error_t companion_proxy_stop_forwarding_service_port(companion_proxy_client_t client, uint16_t remote_port)
 {
 	if (!client) {
 		return COMPANION_PROXY_E_INVALID_ARG;

--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -63,7 +63,7 @@ static debugserver_error_t debugserver_error(service_error_t err)
 	return DEBUGSERVER_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t* client)
+debugserver_error_t debugserver_client_new(idevice_t device, lockdownd_service_descriptor_t service, debugserver_client_t* client)
 {
 	*client = NULL;
 
@@ -95,7 +95,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_new(idevice_t device
 	return DEBUGSERVER_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label)
+debugserver_error_t debugserver_client_start_service(idevice_t device, debugserver_client_t * client, const char* label)
 {
 	debugserver_error_t err = DEBUGSERVER_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, DEBUGSERVER_SECURE_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(debugserver_client_new), &err);
@@ -106,7 +106,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_start_service(idevic
 	return err;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_free(debugserver_client_t client)
+debugserver_error_t debugserver_client_free(debugserver_client_t client)
 {
 	if (!client)
 		return DEBUGSERVER_E_INVALID_ARG;
@@ -118,7 +118,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_free(debugserver_cli
 	return err;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent)
+debugserver_error_t debugserver_client_send(debugserver_client_t client, const char* data, uint32_t size, uint32_t *sent)
 {
 	debugserver_error_t res = DEBUGSERVER_E_UNKNOWN_ERROR;
 	int bytes = 0;
@@ -139,7 +139,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_send(debugserver_cli
 	return res;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
+debugserver_error_t debugserver_client_receive_with_timeout(debugserver_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
 {
 	debugserver_error_t res = DEBUGSERVER_E_UNKNOWN_ERROR;
 	int bytes = 0;
@@ -159,12 +159,12 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_with_timeout
 	return (bytes > 0) ? DEBUGSERVER_E_SUCCESS : res;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive(debugserver_client_t client, char* data, uint32_t size, uint32_t *received)
+debugserver_error_t debugserver_client_receive(debugserver_client_t client, char* data, uint32_t size, uint32_t *received)
 {
 	return debugserver_client_receive_with_timeout(client, data, size, received, 1000);
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command)
+debugserver_error_t debugserver_command_new(const char* name, int argc, char* argv[], debugserver_command_t* command)
 {
 	int i;
 	debugserver_command_t tmp = (debugserver_command_t) malloc(sizeof(struct debugserver_command_private));
@@ -189,7 +189,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_command_new(const char* nam
 	return DEBUGSERVER_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_command_free(debugserver_command_t command)
+debugserver_error_t debugserver_command_free(debugserver_command_t command)
 {
 	int i;
 	debugserver_error_t res = DEBUGSERVER_E_UNKNOWN_ERROR;
@@ -267,7 +267,7 @@ static int debugserver_response_is_checksum_valid(const char* response, uint32_t
 	return 1;
 }
 
-LIBIMOBILEDEVICE_API void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length)
+void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length)
 {
 	uint32_t position;
 	uint32_t index;
@@ -283,7 +283,7 @@ LIBIMOBILEDEVICE_API void debugserver_encode_string(const char* buffer, char** e
 	}
 }
 
-LIBIMOBILEDEVICE_API void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer)
+void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer)
 {
 	*buffer = malloc(sizeof(char) * ((encoded_length / 2)+1));
 	char* t = *buffer;
@@ -342,7 +342,7 @@ static debugserver_error_t debugserver_client_send_noack(debugserver_client_t cl
 	return debugserver_client_send(client, "-", sizeof(char), NULL);
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled)
+debugserver_error_t debugserver_client_set_ack_mode(debugserver_client_t client, int enabled)
 {
 	if (!client)
 		return DEBUGSERVER_E_INVALID_ARG;
@@ -378,7 +378,7 @@ static int debugserver_client_receive_internal_check(debugserver_client_t client
 	return did_receive_char;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response, size_t* response_size)
+debugserver_error_t debugserver_client_receive_response(debugserver_client_t client, char** response, size_t* response_size)
 {
 	debugserver_error_t res = DEBUGSERVER_E_SUCCESS;
 
@@ -491,7 +491,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_receive_response(deb
 	return res;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response, size_t* response_size)
+debugserver_error_t debugserver_client_send_command(debugserver_client_t client, debugserver_command_t command, char** response, size_t* response_size)
 {
 	debugserver_error_t res = DEBUGSERVER_E_SUCCESS;
 	int i;
@@ -547,7 +547,7 @@ cleanup:
 	return res;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response)
+debugserver_error_t debugserver_client_set_environment_hex_encoded(debugserver_client_t client, const char* env, char** response)
 {
 	if (!client || !env)
 		return DEBUGSERVER_E_INVALID_ARG;
@@ -566,7 +566,7 @@ LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_environment_hex_
 	return result;
 }
 
-LIBIMOBILEDEVICE_API debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response)
+debugserver_error_t debugserver_client_set_argv(debugserver_client_t client, int argc, char* argv[], char** response)
 {
 	if (!client || !argc)
 		return DEBUGSERVER_E_INVALID_ARG;

--- a/src/diagnostics_relay.c
+++ b/src/diagnostics_relay.c
@@ -73,7 +73,7 @@ static int diagnostics_relay_check_result(plist_t dict)
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client)
+diagnostics_relay_error_t diagnostics_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, diagnostics_relay_client_t *client)
 {
 	if (!device || !service || service->port == 0 || !client || *client) {
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -93,14 +93,14 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_new(idev
 	return DIAGNOSTICS_RELAY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t * client, const char* label)
+diagnostics_relay_error_t diagnostics_relay_client_start_service(idevice_t device, diagnostics_relay_client_t * client, const char* label)
 {
 	diagnostics_relay_error_t err = DIAGNOSTICS_RELAY_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, DIAGNOSTICS_RELAY_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(diagnostics_relay_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client)
+diagnostics_relay_error_t diagnostics_relay_client_free(diagnostics_relay_client_t client)
 {
 	if (!client)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -167,7 +167,7 @@ static diagnostics_relay_error_t diagnostics_relay_send(diagnostics_relay_client
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client)
+diagnostics_relay_error_t diagnostics_relay_goodbye(diagnostics_relay_client_t client)
 {
 	if (!client)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -201,7 +201,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_goodbye(diagnos
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client)
+diagnostics_relay_error_t diagnostics_relay_sleep(diagnostics_relay_client_t client)
 {
 	if (!client)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -277,17 +277,17 @@ static diagnostics_relay_error_t internal_diagnostics_relay_action(diagnostics_r
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
+diagnostics_relay_error_t diagnostics_relay_restart(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
 {
 	return internal_diagnostics_relay_action(client, "Restart", flags);
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
+diagnostics_relay_error_t diagnostics_relay_shutdown(diagnostics_relay_client_t client, diagnostics_relay_action_t flags)
 {
 	return internal_diagnostics_relay_action(client, "Shutdown", flags);
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics)
+diagnostics_relay_error_t diagnostics_relay_request_diagnostics(diagnostics_relay_client_t client, const char* type, plist_t* diagnostics)
 {
 	if (!client || diagnostics == NULL)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -328,7 +328,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_request_diagnos
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result)
+diagnostics_relay_error_t diagnostics_relay_query_mobilegestalt(diagnostics_relay_client_t client, plist_t keys, plist_t* result)
 {
 	if (!client || plist_get_node_type(keys) != PLIST_ARRAY || result == NULL)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -370,7 +370,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_mobileges
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* entry_name, const char* entry_class, plist_t* result)
+diagnostics_relay_error_t diagnostics_relay_query_ioregistry_entry(diagnostics_relay_client_t client, const char* entry_name, const char* entry_class, plist_t* result)
 {
 	if (!client || (entry_name == NULL && entry_class == NULL) || result == NULL)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;
@@ -415,7 +415,7 @@ LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_ioregistr
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result)
+diagnostics_relay_error_t diagnostics_relay_query_ioregistry_plane(diagnostics_relay_client_t client, const char* plane, plist_t* result)
 {
 	if (!client || plane == NULL || result == NULL)
 		return DIAGNOSTICS_RELAY_E_INVALID_ARG;

--- a/src/file_relay.c
+++ b/src/file_relay.c
@@ -28,7 +28,7 @@
 #include "property_list_service.h"
 #include "common/debug.h"
 
-LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client)
+file_relay_error_t file_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, file_relay_client_t *client)
 {
 	if (!device || !service || service->port == 0 || !client || *client) {
 		return FILE_RELAY_E_INVALID_ARG;
@@ -48,14 +48,14 @@ LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_new(idevice_t device, 
 	return FILE_RELAY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t * client, const char* label)
+file_relay_error_t file_relay_client_start_service(idevice_t device, file_relay_client_t * client, const char* label)
 {
 	file_relay_error_t err = FILE_RELAY_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, FILE_RELAY_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(file_relay_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_free(file_relay_client_t client)
+file_relay_error_t file_relay_client_free(file_relay_client_t client)
 {
 	if (!client)
 		return FILE_RELAY_E_INVALID_ARG;
@@ -67,7 +67,7 @@ LIBIMOBILEDEVICE_API file_relay_error_t file_relay_client_free(file_relay_client
 	return FILE_RELAY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout)
+file_relay_error_t file_relay_request_sources_timeout(file_relay_client_t client, const char **sources, idevice_connection_t *connection, unsigned int timeout)
 {
 	if (!client || !client->parent || !sources || !sources[0]) {
 		return FILE_RELAY_E_INVALID_ARG;
@@ -159,7 +159,7 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection)
+file_relay_error_t file_relay_request_sources(file_relay_client_t client, const char **sources, idevice_connection_t *connection)
 {
 	return file_relay_request_sources_timeout(client, sources, connection, 60000);
 }

--- a/src/heartbeat.c
+++ b/src/heartbeat.c
@@ -62,7 +62,7 @@ static heartbeat_error_t heartbeat_error(property_list_service_error_t err)
 	return HEARTBEAT_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client)
+heartbeat_error_t heartbeat_client_new(idevice_t device, lockdownd_service_descriptor_t service, heartbeat_client_t * client)
 {
 	*client = NULL;
 
@@ -89,14 +89,14 @@ LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_new(idevice_t device, lo
 	return 0;
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label)
+heartbeat_error_t heartbeat_client_start_service(idevice_t device, heartbeat_client_t * client, const char* label)
 {
 	heartbeat_error_t err = HEARTBEAT_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, HEARTBEAT_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(heartbeat_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_free(heartbeat_client_t client)
+heartbeat_error_t heartbeat_client_free(heartbeat_client_t client)
 {
 	if (!client)
 		return HEARTBEAT_E_INVALID_ARG;
@@ -107,7 +107,7 @@ LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_client_free(heartbeat_client_t 
 	return err;
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist)
+heartbeat_error_t heartbeat_send(heartbeat_client_t client, plist_t plist)
 {
 	heartbeat_error_t res = HEARTBEAT_E_UNKNOWN_ERROR;
 
@@ -122,12 +122,12 @@ LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_send(heartbeat_client_t client,
 	return res;
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist)
+heartbeat_error_t heartbeat_receive(heartbeat_client_t client, plist_t * plist)
 {
 	return heartbeat_receive_with_timeout(client, plist, 1000);
 }
 
-LIBIMOBILEDEVICE_API heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms)
+heartbeat_error_t heartbeat_receive_with_timeout(heartbeat_client_t client, plist_t * plist, uint32_t timeout_ms)
 {
 	heartbeat_error_t res = HEARTBEAT_E_UNKNOWN_ERROR;
 	plist_t outplist = NULL;

--- a/src/house_arrest.c
+++ b/src/house_arrest.c
@@ -58,7 +58,7 @@ static house_arrest_error_t house_arrest_error(property_list_service_error_t err
 	return HOUSE_ARREST_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client)
+house_arrest_error_t house_arrest_client_new(idevice_t device, lockdownd_service_descriptor_t service, house_arrest_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	house_arrest_error_t err = house_arrest_error(property_list_service_client_new(device, service, &plistclient));
@@ -74,14 +74,14 @@ LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_new(idevice_t devi
 	return HOUSE_ARREST_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t * client, const char* label)
+house_arrest_error_t house_arrest_client_start_service(idevice_t device, house_arrest_client_t * client, const char* label)
 {
 	house_arrest_error_t err = HOUSE_ARREST_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, HOUSE_ARREST_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(house_arrest_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_free(house_arrest_client_t client)
+house_arrest_error_t house_arrest_client_free(house_arrest_client_t client)
 {
 	if (!client)
 		return HOUSE_ARREST_E_INVALID_ARG;
@@ -96,7 +96,7 @@ LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_client_free(house_arrest_
 	return err;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict)
+house_arrest_error_t house_arrest_send_request(house_arrest_client_t client, plist_t dict)
 {
 	if (!client || !client->parent || !dict)
 		return HOUSE_ARREST_E_INVALID_ARG;
@@ -112,7 +112,7 @@ LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_request(house_arrest
 	return res;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid)
+house_arrest_error_t house_arrest_send_command(house_arrest_client_t client, const char *command, const char *appid)
 {
 	if (!client || !client->parent || !command || !appid)
 		return HOUSE_ARREST_E_INVALID_ARG;
@@ -132,7 +132,7 @@ LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_send_command(house_arrest
 	return res;
 }
 
-LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict)
+house_arrest_error_t house_arrest_get_result(house_arrest_client_t client, plist_t *dict)
 {
 	if (!client || !client->parent)
 		return HOUSE_ARREST_E_INVALID_ARG;
@@ -150,7 +150,7 @@ LIBIMOBILEDEVICE_API house_arrest_error_t house_arrest_get_result(house_arrest_c
 	return res;
 }
 
-LIBIMOBILEDEVICE_API afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client)
+afc_error_t afc_client_new_from_house_arrest_client(house_arrest_client_t client, afc_client_t *afc_client)
 {
 	if (!client || !client->parent || (client->mode == HOUSE_ARREST_CLIENT_MODE_AFC)) {
 		return AFC_E_INVALID_ARG;

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -209,7 +209,7 @@ static void usbmux_event_cb(const usbmuxd_event_t *event, void *user_data)
 	}
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data)
+idevice_error_t idevice_event_subscribe(idevice_event_cb_t callback, void *user_data)
 {
 	event_cb = callback;
 	int res = usbmuxd_subscribe(usbmux_event_cb, user_data);
@@ -221,7 +221,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_event_subscribe(idevice_event_cb_t 
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_event_unsubscribe(void)
+idevice_error_t idevice_event_unsubscribe(void)
 {
 	event_cb = NULL;
 	int res = usbmuxd_unsubscribe();
@@ -232,7 +232,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_event_unsubscribe(void)
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list_extended(idevice_info_t **devices, int *count)
+idevice_error_t idevice_get_device_list_extended(idevice_info_t **devices, int *count)
 {
 	usbmuxd_device_info_t *dev_list;
 
@@ -273,7 +273,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list_extended(idevice_in
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_extended_free(idevice_info_t *devices)
+idevice_error_t idevice_device_list_extended_free(idevice_info_t *devices)
 {
 	if (devices) {
 		int i = 0;
@@ -288,7 +288,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_extended_free(idevice_i
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list(char ***devices, int *count)
+idevice_error_t idevice_get_device_list(char ***devices, int *count)
 {
 	usbmuxd_device_info_t *dev_list;
 
@@ -320,7 +320,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_get_device_list(char ***devices, in
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_free(char **devices)
+idevice_error_t idevice_device_list_free(char **devices)
 {
 	if (devices) {
 		int i = 0;
@@ -333,7 +333,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_free(char **devices)
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API void idevice_set_debug_level(int level)
+void idevice_set_debug_level(int level)
 {
 	internal_set_debug_level(level);
 }
@@ -369,7 +369,7 @@ static idevice_t idevice_from_mux_device(usbmuxd_device_info_t *muxdev)
 	return device;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_new_with_options(idevice_t * device, const char *udid, enum idevice_options options)
+idevice_error_t idevice_new_with_options(idevice_t * device, const char *udid, enum idevice_options options)
 {
 	usbmuxd_device_info_t muxdev;
 	int usbmux_options = 0;
@@ -393,12 +393,12 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_new_with_options(idevice_t * device
 	return IDEVICE_E_NO_DEVICE;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_new(idevice_t * device, const char *udid)
+idevice_error_t idevice_new(idevice_t * device, const char *udid)
 {
 	return idevice_new_with_options(device, udid, 0);
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_free(idevice_t device)
+idevice_error_t idevice_free(idevice_t device)
 {
 	if (!device)
 		return IDEVICE_E_INVALID_ARG;
@@ -415,7 +415,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_free(idevice_t device)
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection)
+idevice_error_t idevice_connect(idevice_t device, uint16_t port, idevice_connection_t *connection)
 {
 	if (!device) {
 		return IDEVICE_E_INVALID_ARG;
@@ -489,7 +489,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connect(idevice_t device, uint16_t 
 	return IDEVICE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_disconnect(idevice_connection_t connection)
+idevice_error_t idevice_disconnect(idevice_connection_t connection)
 {
 	if (!connection) {
 		return IDEVICE_E_INVALID_ARG;
@@ -551,7 +551,7 @@ static idevice_error_t internal_connection_send(idevice_connection_t connection,
 
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes)
+idevice_error_t idevice_connection_send(idevice_connection_t connection, const char *data, uint32_t len, uint32_t *sent_bytes)
 {
 	if (!connection || !data || (connection->ssl_data && !connection->ssl_data->session)) {
 		return IDEVICE_E_INVALID_ARG;
@@ -660,7 +660,7 @@ static idevice_error_t internal_connection_receive_timeout(idevice_connection_t 
 	return IDEVICE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout)
+idevice_error_t idevice_connection_receive_timeout(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes, unsigned int timeout)
 {
 	if (!connection || (connection->ssl_data && !connection->ssl_data->session) || len == 0) {
 		return IDEVICE_E_INVALID_ARG;
@@ -754,7 +754,7 @@ static idevice_error_t internal_connection_receive(idevice_connection_t connecti
 	return IDEVICE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes)
+idevice_error_t idevice_connection_receive(idevice_connection_t connection, char *data, uint32_t len, uint32_t *recv_bytes)
 {
 	if (!connection || (connection->ssl_data && !connection->ssl_data->session)) {
 		return IDEVICE_E_INVALID_ARG;
@@ -777,7 +777,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_receive(idevice_connecti
 	return internal_connection_receive(connection, data, len, recv_bytes);
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd)
+idevice_error_t idevice_connection_get_fd(idevice_connection_t connection, int *fd)
 {
 	if (!connection || !fd) {
 		return IDEVICE_E_INVALID_ARG;
@@ -796,7 +796,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_get_fd(idevice_connectio
 	return result;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle)
+idevice_error_t idevice_get_handle(idevice_t device, uint32_t *handle)
 {
 	if (!device || !handle)
 		return IDEVICE_E_INVALID_ARG;
@@ -805,7 +805,7 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_get_handle(idevice_t device, uint32
 	return IDEVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_get_udid(idevice_t device, char **udid)
+idevice_error_t idevice_get_udid(idevice_t device, char **udid)
 {
 	if (!device || !udid)
 		return IDEVICE_E_INVALID_ARG;
@@ -983,7 +983,7 @@ static int internal_cert_callback(gnutls_session_t session, const gnutls_datum_t
 }
 #endif
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection)
+idevice_error_t idevice_connection_enable_ssl(idevice_connection_t connection)
 {
 	if (!connection || connection->ssl_data)
 		return IDEVICE_E_INVALID_ARG;
@@ -1170,12 +1170,12 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_enable_ssl(idevice_conne
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection)
+idevice_error_t idevice_connection_disable_ssl(idevice_connection_t connection)
 {
 	return idevice_connection_disable_bypass_ssl(connection, 0);
 }
 
-LIBIMOBILEDEVICE_API idevice_error_t idevice_connection_disable_bypass_ssl(idevice_connection_t connection, uint8_t sslBypass)
+idevice_error_t idevice_connection_disable_bypass_ssl(idevice_connection_t connection, uint8_t sslBypass)
 {
 	if (!connection)
 		return IDEVICE_E_INVALID_ARG;

--- a/src/idevice.h
+++ b/src/idevice.h
@@ -33,16 +33,6 @@
 #include <gnutls/x509.h>
 #endif
 
-#ifdef WIN32
-#define LIBIMOBILEDEVICE_API __declspec( dllexport )
-#else
-#ifdef HAVE_FVISIBILITY
-#define LIBIMOBILEDEVICE_API __attribute__((visibility("default")))
-#else
-#define LIBIMOBILEDEVICE_API
-#endif
-#endif
-
 #include "common/userpref.h"
 #include "libimobiledevice/libimobiledevice.h"
 

--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -232,7 +232,7 @@ static instproxy_error_t instproxy_error(property_list_service_error_t err)
 	return INSTPROXY_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client)
+instproxy_error_t instproxy_client_new(idevice_t device, lockdownd_service_descriptor_t service, instproxy_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	instproxy_error_t err = instproxy_error(property_list_service_client_new(device, service, &plistclient));
@@ -249,14 +249,14 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_new(idevice_t device, lo
 	return INSTPROXY_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label)
+instproxy_error_t instproxy_client_start_service(idevice_t device, instproxy_client_t * client, const char* label)
 {
 	instproxy_error_t err = INSTPROXY_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, INSTPROXY_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(instproxy_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_free(instproxy_client_t client)
+instproxy_error_t instproxy_client_free(instproxy_client_t client)
 {
 	if (!client)
 		return INSTPROXY_E_INVALID_ARG;
@@ -531,7 +531,7 @@ static instproxy_error_t instproxy_perform_command(instproxy_client_t client, pl
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_browse_with_callback(instproxy_client_t client, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	if (!client || !client->parent || !status_cb)
 		return INSTPROXY_E_INVALID_ARG;
@@ -572,7 +572,7 @@ static void instproxy_append_current_list_to_result_cb(plist_t command, plist_t 
 		plist_free(current_list);
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result)
+instproxy_error_t instproxy_browse(instproxy_client_t client, plist_t client_options, plist_t *result)
 {
 	if (!client || !client->parent || !result)
 		return INSTPROXY_E_INVALID_ARG;
@@ -609,7 +609,7 @@ static void instproxy_copy_lookup_result_cb(plist_t command, plist_t status, voi
 	}
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result)
+instproxy_error_t instproxy_lookup(instproxy_client_t client, const char** appids, plist_t client_options, plist_t *result)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 	int i = 0;
@@ -656,7 +656,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup(instproxy_client_t clien
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_install(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -673,7 +673,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_install(instproxy_client_t clie
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_upgrade(instproxy_client_t client, const char *pkg_path, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -690,7 +690,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_upgrade(instproxy_client_t clie
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_uninstall(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -707,7 +707,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_uninstall(instproxy_client_t cl
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result)
+instproxy_error_t instproxy_lookup_archives(instproxy_client_t client, plist_t client_options, plist_t *result)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -723,7 +723,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_lookup_archives(instproxy_clien
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -740,7 +740,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_archive(instproxy_client_t clie
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_restore(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -757,7 +757,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_restore(instproxy_client_t clie
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
+instproxy_error_t instproxy_remove_archive(instproxy_client_t client, const char *appid, plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -774,7 +774,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_remove_archive(instproxy_client
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result)
+instproxy_error_t instproxy_check_capabilities_match(instproxy_client_t client, const char** capabilities, plist_t client_options, plist_t *result)
 {
 	if (!client || !capabilities || !result)
 		return INSTPROXY_E_INVALID_ARG;
@@ -811,7 +811,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_check_capabilities_match(instpr
 	return res;
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code)
+instproxy_error_t instproxy_status_get_error(plist_t status, char **name, char** description, uint64_t* code)
 {
 	instproxy_error_t res = INSTPROXY_E_UNKNOWN_ERROR;
 
@@ -849,7 +849,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_status_get_error(plist_t status
 	return res;
 }
 
-LIBIMOBILEDEVICE_API void instproxy_status_get_name(plist_t status, char **name)
+void instproxy_status_get_name(plist_t status, char **name)
 {
 	if (name) {
 		plist_t node = plist_dict_get_item(status, "Status");
@@ -861,7 +861,7 @@ LIBIMOBILEDEVICE_API void instproxy_status_get_name(plist_t status, char **name)
 	}
 }
 
-LIBIMOBILEDEVICE_API void instproxy_status_get_percent_complete(plist_t status, int *percent)
+void instproxy_status_get_percent_complete(plist_t status, int *percent)
 {
 	uint64_t val = 0;
 	if (percent) {
@@ -873,7 +873,7 @@ LIBIMOBILEDEVICE_API void instproxy_status_get_percent_complete(plist_t status, 
 	}
 }
 
-LIBIMOBILEDEVICE_API void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list)
+void instproxy_status_get_current_list(plist_t status, uint64_t* total, uint64_t* current_index, uint64_t* current_amount, plist_t* list)
 {
 	plist_t node = NULL;
 
@@ -910,7 +910,7 @@ LIBIMOBILEDEVICE_API void instproxy_status_get_current_list(plist_t status, uint
 	}
 }
 
-LIBIMOBILEDEVICE_API void instproxy_command_get_name(plist_t command, char** name)
+void instproxy_command_get_name(plist_t command, char** name)
 {
 	if (name) {
 		plist_t node = plist_dict_get_item(command, "Command");
@@ -922,12 +922,12 @@ LIBIMOBILEDEVICE_API void instproxy_command_get_name(plist_t command, char** nam
 	}
 }
 
-LIBIMOBILEDEVICE_API plist_t instproxy_client_options_new(void)
+plist_t instproxy_client_options_new(void)
 {
 	return plist_new_dict();
 }
 
-LIBIMOBILEDEVICE_API void instproxy_client_options_add(plist_t client_options, ...)
+void instproxy_client_options_add(plist_t client_options, ...)
 {
 	if (!client_options)
 		return;
@@ -961,7 +961,7 @@ LIBIMOBILEDEVICE_API void instproxy_client_options_add(plist_t client_options, .
 	va_end(args);
 }
 
-LIBIMOBILEDEVICE_API void instproxy_client_options_set_return_attributes(plist_t client_options, ...)
+void instproxy_client_options_set_return_attributes(plist_t client_options, ...)
 {
 	if (!client_options)
 		return;
@@ -982,14 +982,14 @@ LIBIMOBILEDEVICE_API void instproxy_client_options_set_return_attributes(plist_t
 	plist_dict_set_item(client_options, "ReturnAttributes", return_attributes);
 }
 
-LIBIMOBILEDEVICE_API void instproxy_client_options_free(plist_t client_options)
+void instproxy_client_options_free(plist_t client_options)
 {
 	if (client_options) {
 		plist_free(client_options);
 	}
 }
 
-LIBIMOBILEDEVICE_API instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* appid, char** path)
+instproxy_error_t instproxy_client_get_path_for_bundle_identifier(instproxy_client_t client, const char* appid, char** path)
 {
 	if (!client || !client->parent || !appid)
 		return INSTPROXY_E_INVALID_ARG;

--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -242,7 +242,7 @@ static void plist_dict_add_label(plist_t plist, const char *label)
 	}
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id)
+lockdownd_error_t lockdownd_stop_session(lockdownd_client_t client, const char *session_id)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -324,7 +324,7 @@ static lockdownd_error_t lockdownd_client_free_simple(lockdownd_client_t client)
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_free(lockdownd_client_t client)
+lockdownd_error_t lockdownd_client_free(lockdownd_client_t client)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -340,7 +340,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_free(lockdownd_client_t 
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API void lockdownd_client_set_label(lockdownd_client_t client, const char *label)
+void lockdownd_client_set_label(lockdownd_client_t client, const char *label)
 {
 	if (client) {
 		if (client->label)
@@ -350,7 +350,7 @@ LIBIMOBILEDEVICE_API void lockdownd_client_set_label(lockdownd_client_t client, 
 	}
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist)
+lockdownd_error_t lockdownd_receive(lockdownd_client_t client, plist_t *plist)
 {
 	if (!client || !plist || (plist && *plist))
 		return LOCKDOWN_E_INVALID_ARG;
@@ -358,7 +358,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_receive(lockdownd_client_t clie
 	return lockdownd_error(property_list_service_receive_plist(client->parent, plist));
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist)
+lockdownd_error_t lockdownd_send(lockdownd_client_t client, plist_t plist)
 {
 	if (!client || !plist)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -366,7 +366,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_send(lockdownd_client_t client,
 	return lockdownd_error(property_list_service_send_xml_plist(client->parent, plist));
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type)
+lockdownd_error_t lockdownd_query_type(lockdownd_client_t client, char **type)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -411,7 +411,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_query_type(lockdownd_client_t c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value)
+lockdownd_error_t lockdownd_get_value(lockdownd_client_t client, const char *domain, const char *key, plist_t *value)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -465,7 +465,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_value(lockdownd_client_t cl
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value)
+lockdownd_error_t lockdownd_set_value(lockdownd_client_t client, const char *domain, const char *key, plist_t value)
 {
 	if (!client || !value)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -513,7 +513,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_set_value(lockdownd_client_t cl
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key)
+lockdownd_error_t lockdownd_remove_value(lockdownd_client_t client, const char *domain, const char *key)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -560,7 +560,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_remove_value(lockdownd_client_t
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **udid)
+lockdownd_error_t lockdownd_get_device_udid(lockdownd_client_t client, char **udid)
 {
 	lockdownd_error_t ret = LOCKDOWN_E_UNKNOWN_ERROR;
 	plist_t value = NULL;
@@ -606,7 +606,7 @@ static lockdownd_error_t lockdownd_get_device_public_key_as_key_data(lockdownd_c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name)
+lockdownd_error_t lockdownd_get_device_name(lockdownd_client_t client, char **device_name)
 {
 	lockdownd_error_t ret = LOCKDOWN_E_UNKNOWN_ERROR;
 	plist_t value = NULL;
@@ -623,7 +623,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_device_name(lockdownd_clien
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label)
+lockdownd_error_t lockdownd_client_new(idevice_t device, lockdownd_client_t *client, const char *label)
 {
 	if (!device || !client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -657,7 +657,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new(idevice_t device, lo
 	return LOCKDOWN_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label)
+lockdownd_error_t lockdownd_client_new_with_handshake(idevice_t device, lockdownd_client_t *client, const char *label)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1019,7 +1019,7 @@ static lockdownd_error_t lockdownd_do_pair(lockdownd_client_t client, lockdownd_
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
+lockdownd_error_t lockdownd_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
 {
 
 	plist_t options = plist_new_dict();
@@ -1032,22 +1032,22 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_pair(lockdownd_client_t client,
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_pair_with_options(lockdownd_client_t client, lockdownd_pair_record_t pair_record, plist_t options, plist_t *response)
+lockdownd_error_t lockdownd_pair_with_options(lockdownd_client_t client, lockdownd_pair_record_t pair_record, plist_t options, plist_t *response)
 {
 	return lockdownd_do_pair(client, pair_record, "Pair", options, response);
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
+lockdownd_error_t lockdownd_validate_pair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
 {
 	return lockdownd_do_pair(client, pair_record, "ValidatePair", NULL, NULL);
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
+lockdownd_error_t lockdownd_unpair(lockdownd_client_t client, lockdownd_pair_record_t pair_record)
 {
 	return lockdownd_do_pair(client, pair_record, "Unpair", NULL, NULL);
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client)
+lockdownd_error_t lockdownd_enter_recovery(lockdownd_client_t client)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1077,7 +1077,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_enter_recovery(lockdownd_client
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client)
+lockdownd_error_t lockdownd_goodbye(lockdownd_client_t client)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1111,7 +1111,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_goodbye(lockdownd_client_t clie
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled)
+lockdownd_error_t lockdownd_start_session(lockdownd_client_t client, const char *host_id, char **session_id, int *ssl_enabled)
 {
 	lockdownd_error_t ret = LOCKDOWN_E_SUCCESS;
 	plist_t dict = NULL;
@@ -1347,17 +1347,17 @@ static lockdownd_error_t lockdownd_do_start_service(lockdownd_client_t client, c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service)
+lockdownd_error_t lockdownd_start_service(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service)
 {
 	return lockdownd_do_start_service(client, identifier, 0, service);
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service)
+lockdownd_error_t lockdownd_start_service_with_escrow_bag(lockdownd_client_t client, const char *identifier, lockdownd_service_descriptor_t *service)
 {
 	return lockdownd_do_start_service(client, identifier, 1, service);
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record)
+lockdownd_error_t lockdownd_activate(lockdownd_client_t client, plist_t activation_record)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1396,7 +1396,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_activate(lockdownd_client_t cli
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client)
+lockdownd_error_t lockdownd_deactivate(lockdownd_client_t client)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1443,7 +1443,7 @@ static void str_remove_spaces(char *source)
 	*dest = 0;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count)
+lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd_client_t client, char ***classes, int *count)
 {
 	if (!client)
 		return LOCKDOWN_E_INVALID_ARG;
@@ -1498,7 +1498,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_get_sync_data_classes(lockdownd
 	return LOCKDOWN_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classes)
+lockdownd_error_t lockdownd_data_classes_free(char **classes)
 {
 	if (classes) {
 		int i = 0;
@@ -1510,7 +1510,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_data_classes_free(char **classe
 	return LOCKDOWN_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service)
+lockdownd_error_t lockdownd_service_descriptor_free(lockdownd_service_descriptor_t service)
 {
 	if (service) {
 		free(service->identifier);
@@ -1520,7 +1520,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_service_descriptor_free(lockdow
 	return LOCKDOWN_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API const char* lockdownd_strerror(lockdownd_error_t err)
+const char* lockdownd_strerror(lockdownd_error_t err)
 {
 	switch (err) {
 		case LOCKDOWN_E_SUCCESS:

--- a/src/misagent.c
+++ b/src/misagent.c
@@ -90,7 +90,7 @@ static misagent_error_t misagent_check_result(plist_t response, int* status_code
 	}
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client)
+misagent_error_t misagent_client_new(idevice_t device, lockdownd_service_descriptor_t service, misagent_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	misagent_error_t err = misagent_error(property_list_service_client_new(device, service, &plistclient));
@@ -106,14 +106,14 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_client_new(idevice_t device, lock
 	return MISAGENT_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t * client, const char* label)
+misagent_error_t misagent_client_start_service(idevice_t device, misagent_client_t * client, const char* label)
 {
 	misagent_error_t err = MISAGENT_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MISAGENT_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(misagent_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_client_free(misagent_client_t client)
+misagent_error_t misagent_client_free(misagent_client_t client)
 {
 	if (!client)
 		return MISAGENT_E_INVALID_ARG;
@@ -128,7 +128,7 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_client_free(misagent_client_t cli
 	return err;
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_install(misagent_client_t client, plist_t profile)
+misagent_error_t misagent_install(misagent_client_t client, plist_t profile)
 {
 	if (!client || !client->parent || !profile || (plist_get_node_type(profile) != PLIST_DATA))
 		return MISAGENT_E_INVALID_ARG;
@@ -165,7 +165,7 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_install(misagent_client_t client,
 	return res;
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles)
+misagent_error_t misagent_copy(misagent_client_t client, plist_t* profiles)
 {
 	if (!client || !client->parent || !profiles)
 		return MISAGENT_E_INVALID_ARG;
@@ -205,7 +205,7 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_copy(misagent_client_t client, pl
 
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_copy_all(misagent_client_t client, plist_t* profiles)
+misagent_error_t misagent_copy_all(misagent_client_t client, plist_t* profiles)
 {
 	if (!client || !client->parent || !profiles)
 		return MISAGENT_E_INVALID_ARG;
@@ -245,7 +245,7 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_copy_all(misagent_client_t client
 
 }
 
-LIBIMOBILEDEVICE_API misagent_error_t misagent_remove(misagent_client_t client, const char* profileID)
+misagent_error_t misagent_remove(misagent_client_t client, const char* profileID)
 {
 	if (!client || !client->parent || !profileID)
 		return MISAGENT_E_INVALID_ARG;
@@ -282,7 +282,7 @@ LIBIMOBILEDEVICE_API misagent_error_t misagent_remove(misagent_client_t client, 
 	return res;
 }
 
-LIBIMOBILEDEVICE_API int misagent_get_status_code(misagent_client_t client)
+int misagent_get_status_code(misagent_client_t client)
 {
 	if (!client) {
 		return -1;

--- a/src/mobile_image_mounter.c
+++ b/src/mobile_image_mounter.c
@@ -78,7 +78,7 @@ static mobile_image_mounter_error_t mobile_image_mounter_error(property_list_ser
 	return MOBILE_IMAGE_MOUNTER_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client)
+mobile_image_mounter_error_t mobile_image_mounter_new(idevice_t device, lockdownd_service_descriptor_t service, mobile_image_mounter_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	mobile_image_mounter_error_t err = mobile_image_mounter_error(property_list_service_client_new(device, service, &plistclient));
@@ -95,14 +95,14 @@ LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_new(idevi
 	return MOBILE_IMAGE_MOUNTER_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t * client, const char* label)
+mobile_image_mounter_error_t mobile_image_mounter_start_service(idevice_t device, mobile_image_mounter_client_t * client, const char* label)
 {
 	mobile_image_mounter_error_t err = MOBILE_IMAGE_MOUNTER_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MOBILE_IMAGE_MOUNTER_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(mobile_image_mounter_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client)
+mobile_image_mounter_error_t mobile_image_mounter_free(mobile_image_mounter_client_t client)
 {
 	if (!client)
 		return MOBILE_IMAGE_MOUNTER_E_INVALID_ARG;
@@ -115,7 +115,7 @@ LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_free(mobi
 	return MOBILE_IMAGE_MOUNTER_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result)
+mobile_image_mounter_error_t mobile_image_mounter_lookup_image(mobile_image_mounter_client_t client, const char *image_type, plist_t *result)
 {
 	if (!client || !image_type || !result) {
 		return MOBILE_IMAGE_MOUNTER_E_INVALID_ARG;
@@ -181,7 +181,7 @@ static mobile_image_mounter_error_t process_result(plist_t result, const char *e
 	return res;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata)
+mobile_image_mounter_error_t mobile_image_mounter_upload_image(mobile_image_mounter_client_t client, const char *image_type, size_t image_size, const char *signature, uint16_t signature_size, mobile_image_mounter_upload_cb_t upload_cb, void* userdata)
 {
 	if (!client || !image_type || (image_size == 0) || !upload_cb) {
 		return MOBILE_IMAGE_MOUNTER_E_INVALID_ARG;
@@ -260,7 +260,7 @@ leave_unlock:
 
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result)
+mobile_image_mounter_error_t mobile_image_mounter_mount_image(mobile_image_mounter_client_t client, const char *image_path, const char *signature, uint16_t signature_size, const char *image_type, plist_t *result)
 {
 	if (!client || !image_path || !image_type || !result) {
 		return MOBILE_IMAGE_MOUNTER_E_INVALID_ARG;
@@ -292,7 +292,7 @@ leave_unlock:
 	return res;
 }
 
-LIBIMOBILEDEVICE_API mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client)
+mobile_image_mounter_error_t mobile_image_mounter_hangup(mobile_image_mounter_client_t client)
 {
 	if (!client) {
 		return MOBILE_IMAGE_MOUNTER_E_INVALID_ARG;

--- a/src/mobileactivation.c
+++ b/src/mobileactivation.c
@@ -54,7 +54,7 @@ static mobileactivation_error_t mobileactivation_error(property_list_service_err
 	return MOBILEACTIVATION_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobileactivation_client_t *client)
+mobileactivation_error_t mobileactivation_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobileactivation_client_t *client)
 {
 	if (!device || !service || service->port == 0 || !client || *client) {
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -74,14 +74,14 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_new(idevic
 	return MOBILEACTIVATION_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_start_service(idevice_t device, mobileactivation_client_t * client, const char* label)
+mobileactivation_error_t mobileactivation_client_start_service(idevice_t device, mobileactivation_client_t * client, const char* label)
 {
 	mobileactivation_error_t err = MOBILEACTIVATION_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MOBILEACTIVATION_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(mobileactivation_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_client_free(mobileactivation_client_t client)
+mobileactivation_error_t mobileactivation_client_free(mobileactivation_client_t client)
 {
 	if (!client)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -179,7 +179,7 @@ static mobileactivation_error_t mobileactivation_send_command(mobileactivation_c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_get_activation_state(mobileactivation_client_t client, plist_t *state)
+mobileactivation_error_t mobileactivation_get_activation_state(mobileactivation_client_t client, plist_t *state)
 {
 	if (!client || !state)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -201,7 +201,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_get_activation_st
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_session_info(mobileactivation_client_t client, plist_t *blob)
+mobileactivation_error_t mobileactivation_create_activation_session_info(mobileactivation_client_t client, plist_t *blob)
 {
 	if (!client || !blob)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -221,7 +221,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_info(mobileactivation_client_t client, plist_t *info)
+mobileactivation_error_t mobileactivation_create_activation_info(mobileactivation_client_t client, plist_t *info)
 {
 	if (!client || !info)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -243,7 +243,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation_info_with_session(mobileactivation_client_t client, plist_t handshake_response, plist_t *info)
+mobileactivation_error_t mobileactivation_create_activation_info_with_session(mobileactivation_client_t client, plist_t handshake_response, plist_t *info)
 {
 	if (!client || !info)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -267,7 +267,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_create_activation
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate(mobileactivation_client_t client, plist_t activation_record)
+mobileactivation_error_t mobileactivation_activate(mobileactivation_client_t client, plist_t activation_record)
 {
 	if (!client || !activation_record)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -280,7 +280,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate(mobileac
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate_with_session(mobileactivation_client_t client, plist_t activation_record, plist_t headers)
+mobileactivation_error_t mobileactivation_activate_with_session(mobileactivation_client_t client, plist_t activation_record, plist_t headers)
 {
 	if (!client || !activation_record)
 		return MOBILEACTIVATION_E_INVALID_ARG;
@@ -303,7 +303,7 @@ LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_activate_with_ses
 }
 
 
-LIBIMOBILEDEVICE_API mobileactivation_error_t mobileactivation_deactivate(mobileactivation_client_t client)
+mobileactivation_error_t mobileactivation_deactivate(mobileactivation_client_t client)
 {
 	if (!client)
 		return MOBILEACTIVATION_E_INVALID_ARG;

--- a/src/mobilebackup.c
+++ b/src/mobilebackup.c
@@ -68,7 +68,7 @@ static mobilebackup_error_t mobilebackup_error(device_link_service_error_t err)
 	return MOBILEBACKUP_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client)
+mobilebackup_error_t mobilebackup_client_new(idevice_t device, lockdownd_service_descriptor_t service, mobilebackup_client_t * client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -95,14 +95,14 @@ LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_new(idevice_t devi
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t * client, const char* label)
+mobilebackup_error_t mobilebackup_client_start_service(idevice_t device, mobilebackup_client_t * client, const char* label)
 {
 	mobilebackup_error_t err = MOBILEBACKUP_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MOBILEBACKUP_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(mobilebackup_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client)
+mobilebackup_error_t mobilebackup_client_free(mobilebackup_client_t client)
 {
 	if (!client)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -115,7 +115,7 @@ LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_client_free(mobilebackup_
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t * plist)
+mobilebackup_error_t mobilebackup_receive(mobilebackup_client_t client, plist_t * plist)
 {
 	if (!client)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -123,7 +123,7 @@ LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive(mobilebackup_clie
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist)
+mobilebackup_error_t mobilebackup_send(mobilebackup_client_t client, plist_t plist)
 {
 	if (!client || !plist)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -240,7 +240,7 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version)
+mobilebackup_error_t mobilebackup_request_backup(mobilebackup_client_t client, plist_t backup_manifest, const char *base_path, const char *proto_version)
 {
 	if (!client || !client->parent || !base_path || !proto_version)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -300,12 +300,12 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client)
+mobilebackup_error_t mobilebackup_send_backup_file_received(mobilebackup_client_t client)
 {
 	return mobilebackup_send_message(client, "kBackupMessageBackupFileReceived", NULL);
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version)
+mobilebackup_error_t mobilebackup_request_restore(mobilebackup_client_t client, plist_t backup_manifest, mobilebackup_flags_t flags, const char *proto_version)
 {
 	if (!client || !client->parent || !backup_manifest || !proto_version)
 		return MOBILEBACKUP_E_INVALID_ARG;
@@ -359,17 +359,17 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result)
+mobilebackup_error_t mobilebackup_receive_restore_file_received(mobilebackup_client_t client, plist_t *result)
 {
 	return mobilebackup_receive_message(client, "BackupMessageRestoreFileReceived", result);
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result)
+mobilebackup_error_t mobilebackup_receive_restore_application_received(mobilebackup_client_t client, plist_t *result)
 {
 	return mobilebackup_receive_message(client, "BackupMessageRestoreApplicationReceived", result);
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client)
+mobilebackup_error_t mobilebackup_send_restore_complete(mobilebackup_client_t client)
 {
 	mobilebackup_error_t err = mobilebackup_send_message(client, "BackupMessageRestoreComplete", NULL);
 	if (err != MOBILEBACKUP_E_SUCCESS) {
@@ -414,7 +414,7 @@ LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_restore_complete(mob
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason)
+mobilebackup_error_t mobilebackup_send_error(mobilebackup_client_t client, const char *reason)
 {
 	if (!client || !client->parent || !reason)
 		return MOBILEBACKUP_E_INVALID_ARG;

--- a/src/mobilebackup2.c
+++ b/src/mobilebackup2.c
@@ -68,7 +68,7 @@ static mobilebackup2_error_t mobilebackup2_error(device_link_service_error_t err
 	return MOBILEBACKUP2_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service,
+mobilebackup2_error_t mobilebackup2_client_new(idevice_t device, lockdownd_service_descriptor_t service,
 						mobilebackup2_client_t * client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
@@ -96,14 +96,14 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_new(idevice_t de
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t * client, const char* label)
+mobilebackup2_error_t mobilebackup2_client_start_service(idevice_t device, mobilebackup2_client_t * client, const char* label)
 {
 	mobilebackup2_error_t err = MOBILEBACKUP2_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MOBILEBACKUP2_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(mobilebackup2_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client)
+mobilebackup2_error_t mobilebackup2_client_free(mobilebackup2_client_t client)
 {
 	if (!client)
 		return MOBILEBACKUP2_E_INVALID_ARG;
@@ -116,7 +116,7 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_client_free(mobilebacku
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options)
+mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, const char *message, plist_t options)
 {
 	if (!client || !client->parent || (!message && !options))
 		return MOBILEBACKUP2_E_INVALID_ARG;
@@ -214,12 +214,12 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage)
+mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage)
 {
 	return mobilebackup2_error(device_link_service_receive_message(client->parent, msg_plist, dlmessage));
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes)
+mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes)
 {
 	if (!client || !client->parent || !data || (length == 0) || !bytes)
 		return MOBILEBACKUP2_E_INVALID_ARG;
@@ -245,7 +245,7 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_
 	}
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes)
+mobilebackup2_error_t mobilebackup2_receive_raw(mobilebackup2_client_t client, char *data, uint32_t length, uint32_t *bytes)
 {
 	if (!client || !client->parent || !data || (length == 0) || !bytes)
 		return MOBILEBACKUP2_E_INVALID_ARG;
@@ -272,7 +272,7 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_raw(mobilebacku
 	}
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version)
+mobilebackup2_error_t mobilebackup2_version_exchange(mobilebackup2_client_t client, double local_versions[], char count, double *remote_version)
 {
 	int i;
 
@@ -330,7 +330,7 @@ leave:
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options)
+mobilebackup2_error_t mobilebackup2_send_request(mobilebackup2_client_t client, const char *request, const char *target_identifier, const char *source_identifier, plist_t options)
 {
 	if (!client || !client->parent || !request || !target_identifier)
 		return MOBILEBACKUP2_E_INVALID_ARG;
@@ -361,7 +361,7 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_request(mobileback
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2)
+mobilebackup2_error_t mobilebackup2_send_status_response(mobilebackup2_client_t client, int status_code, const char *status1, plist_t status2)
 {
 	if (!client || !client->parent)
 		return MOBILEBACKUP2_E_INVALID_ARG;

--- a/src/mobilesync.c
+++ b/src/mobilesync.c
@@ -71,7 +71,7 @@ static mobilesync_error_t mobilesync_error(device_link_service_error_t err)
 	return MOBILESYNC_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service,
+mobilesync_error_t mobilesync_client_new(idevice_t device, lockdownd_service_descriptor_t service,
 						   mobilesync_client_t * client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
@@ -101,14 +101,14 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_new(idevice_t device, 
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t * client, const char* label)
+mobilesync_error_t mobilesync_client_start_service(idevice_t device, mobilesync_client_t * client, const char* label)
 {
 	mobilesync_error_t err = MOBILESYNC_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, MOBILESYNC_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(mobilesync_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_free(mobilesync_client_t client)
+mobilesync_error_t mobilesync_client_free(mobilesync_client_t client)
 {
 	if (!client)
 		return MOBILESYNC_E_INVALID_ARG;
@@ -118,7 +118,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_client_free(mobilesync_client
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t * plist)
+mobilesync_error_t mobilesync_receive(mobilesync_client_t client, plist_t * plist)
 {
 	if (!client)
 		return MOBILESYNC_E_INVALID_ARG;
@@ -126,14 +126,14 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive(mobilesync_client_t c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist)
+mobilesync_error_t mobilesync_send(mobilesync_client_t client, plist_t plist)
 {
 	if (!client || !plist)
 		return MOBILESYNC_E_INVALID_ARG;
 	return mobilesync_error(device_link_service_send(client->parent, plist));
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description)
+mobilesync_error_t mobilesync_start(mobilesync_client_t client, const char *data_class, mobilesync_anchors_t anchors, uint64_t computer_data_class_version, mobilesync_sync_type_t *sync_type, uint64_t *device_data_class_version, char** error_description)
 {
 	if (!client || client->data_class || !data_class ||
 		!anchors || !anchors->computer_anchor) {
@@ -259,7 +259,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_start(mobilesync_client_t cli
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_finish(mobilesync_client_t client)
+mobilesync_error_t mobilesync_finish(mobilesync_client_t client)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -344,17 +344,17 @@ static mobilesync_error_t mobilesync_get_records(mobilesync_client_t client, con
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client)
+mobilesync_error_t mobilesync_get_all_records_from_device(mobilesync_client_t client)
 {
 	return mobilesync_get_records(client, "SDMessageGetAllRecordsFromDevice");
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client)
+mobilesync_error_t mobilesync_get_changes_from_device(mobilesync_client_t client)
 {
 	return mobilesync_get_records(client, "SDMessageGetChangesFromDevice");
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions)
+mobilesync_error_t mobilesync_receive_changes(mobilesync_client_t client, plist_t *entities, uint8_t *is_last_record, plist_t *actions)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -421,7 +421,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_receive_changes(mobilesync_cl
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client)
+mobilesync_error_t mobilesync_clear_all_records_on_device(mobilesync_client_t client)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -490,7 +490,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_clear_all_records_on_device(m
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client)
+mobilesync_error_t mobilesync_acknowledge_changes_from_device(mobilesync_client_t client)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -524,7 +524,7 @@ static plist_t create_process_changes_message(const char *data_class, plist_t en
 	return msg;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client)
+mobilesync_error_t mobilesync_ready_to_send_changes_from_computer(mobilesync_client_t client)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -591,7 +591,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_ready_to_send_changes_from_co
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions)
+mobilesync_error_t mobilesync_send_changes(mobilesync_client_t client, plist_t entities, uint8_t is_last_record, plist_t actions)
 {
 	if (!client || !client->data_class || !entities) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -619,7 +619,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_send_changes(mobilesync_clien
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping)
+mobilesync_error_t mobilesync_remap_identifiers(mobilesync_client_t client, plist_t *mapping)
 {
 	if (!client || !client->data_class) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -688,7 +688,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_remap_identifiers(mobilesync_
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason)
+mobilesync_error_t mobilesync_cancel(mobilesync_client_t client, const char* reason)
 {
 	if (!client || !client->data_class || !reason) {
 		return MOBILESYNC_E_INVALID_ARG;
@@ -714,7 +714,7 @@ LIBIMOBILEDEVICE_API mobilesync_error_t mobilesync_cancel(mobilesync_client_t cl
 	return err;
 }
 
-LIBIMOBILEDEVICE_API mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor)
+mobilesync_anchors_t mobilesync_anchors_new(const char *device_anchor, const char *computer_anchor)
 {
 	mobilesync_anchors_t anchors = (mobilesync_anchors_t) malloc(sizeof(mobilesync_anchors));
 	if (device_anchor != NULL) {
@@ -731,7 +731,7 @@ LIBIMOBILEDEVICE_API mobilesync_anchors_t mobilesync_anchors_new(const char *dev
 	return anchors;
 }
 
-LIBIMOBILEDEVICE_API void mobilesync_anchors_free(mobilesync_anchors_t anchors)
+void mobilesync_anchors_free(mobilesync_anchors_t anchors)
 {
 	if (anchors->device_anchor != NULL) {
 		free(anchors->device_anchor);
@@ -745,12 +745,12 @@ LIBIMOBILEDEVICE_API void mobilesync_anchors_free(mobilesync_anchors_t anchors)
 	anchors = NULL;
 }
 
-LIBIMOBILEDEVICE_API plist_t mobilesync_actions_new(void)
+plist_t mobilesync_actions_new(void)
 {
 	return plist_new_dict();
 }
 
-LIBIMOBILEDEVICE_API void mobilesync_actions_add(plist_t actions, ...)
+void mobilesync_actions_add(plist_t actions, ...)
 {
 	if (!actions)
 		return;
@@ -782,7 +782,7 @@ LIBIMOBILEDEVICE_API void mobilesync_actions_add(plist_t actions, ...)
 	va_end(args);
 }
 
-LIBIMOBILEDEVICE_API void mobilesync_actions_free(plist_t actions)
+void mobilesync_actions_free(plist_t actions)
 {
 	if (actions) {
 		plist_free(actions);

--- a/src/notification_proxy.c
+++ b/src/notification_proxy.c
@@ -89,7 +89,7 @@ static np_error_t np_error(property_list_service_error_t err)
 	return NP_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client)
+np_error_t np_client_new(idevice_t device, lockdownd_service_descriptor_t service, np_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	np_error_t err = np_error(property_list_service_client_new(device, service, &plistclient));
@@ -107,14 +107,14 @@ LIBIMOBILEDEVICE_API np_error_t np_client_new(idevice_t device, lockdownd_servic
 	return NP_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label)
+np_error_t np_client_start_service(idevice_t device, np_client_t* client, const char* label)
 {
 	np_error_t err = NP_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, NP_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(np_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_client_free(np_client_t client)
+np_error_t np_client_free(np_client_t client)
 {
 	plist_t dict;
 	property_list_service_client_t parent;
@@ -168,7 +168,7 @@ LIBIMOBILEDEVICE_API np_error_t np_client_free(np_client_t client)
 	return NP_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_post_notification(np_client_t client, const char *notification)
+np_error_t np_post_notification(np_client_t client, const char *notification)
 {
 	if (!client || !notification) {
 		return NP_E_INVALID_ARG;
@@ -204,7 +204,7 @@ static np_error_t internal_np_observe_notification(np_client_t client, const cha
 	return res;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_observe_notification( np_client_t client, const char *notification )
+np_error_t np_observe_notification( np_client_t client, const char *notification )
 {
 	if (!client || !notification) {
 		return NP_E_INVALID_ARG;
@@ -215,7 +215,7 @@ LIBIMOBILEDEVICE_API np_error_t np_observe_notification( np_client_t client, con
 	return res;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_observe_notifications(np_client_t client, const char **notification_spec)
+np_error_t np_observe_notifications(np_client_t client, const char **notification_spec)
 {
 	int i = 0;
 	np_error_t res = NP_E_UNKNOWN_ERROR;
@@ -346,7 +346,7 @@ void* np_notifier( void* arg )
 	return NULL;
 }
 
-LIBIMOBILEDEVICE_API np_error_t np_set_notify_callback( np_client_t client, np_notify_cb_t notify_cb, void *user_data )
+np_error_t np_set_notify_callback( np_client_t client, np_notify_cb_t notify_cb, void *user_data )
 {
 	if (!client)
 		return NP_E_INVALID_ARG;

--- a/src/preboard.c
+++ b/src/preboard.c
@@ -62,7 +62,7 @@ static preboard_error_t preboard_error(property_list_service_error_t err)
 	return PREBOARD_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_client_new(idevice_t device, lockdownd_service_descriptor_t service, preboard_client_t * client)
+preboard_error_t preboard_client_new(idevice_t device, lockdownd_service_descriptor_t service, preboard_client_t * client)
 {
 	*client = NULL;
 
@@ -90,14 +90,14 @@ LIBIMOBILEDEVICE_API preboard_error_t preboard_client_new(idevice_t device, lock
 	return 0;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_client_start_service(idevice_t device, preboard_client_t * client, const char* label)
+preboard_error_t preboard_client_start_service(idevice_t device, preboard_client_t * client, const char* label)
 {
 	preboard_error_t err = PREBOARD_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, PREBOARD_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(preboard_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_client_free(preboard_client_t client)
+preboard_error_t preboard_client_free(preboard_client_t client)
 {
 	if (!client)
 		return PREBOARD_E_INVALID_ARG;
@@ -116,7 +116,7 @@ LIBIMOBILEDEVICE_API preboard_error_t preboard_client_free(preboard_client_t cli
 	return err;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_send(preboard_client_t client, plist_t plist)
+preboard_error_t preboard_send(preboard_client_t client, plist_t plist)
 {
 	preboard_error_t res = PREBOARD_E_UNKNOWN_ERROR;
 	res = preboard_error(property_list_service_send_binary_plist(client->parent, plist));
@@ -127,7 +127,7 @@ LIBIMOBILEDEVICE_API preboard_error_t preboard_send(preboard_client_t client, pl
 	return res;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_receive_with_timeout(preboard_client_t client, plist_t * plist, uint32_t timeout_ms)
+preboard_error_t preboard_receive_with_timeout(preboard_client_t client, plist_t * plist, uint32_t timeout_ms)
 {
 	preboard_error_t res = PREBOARD_E_UNKNOWN_ERROR;
 	plist_t outplist = NULL;
@@ -141,7 +141,7 @@ LIBIMOBILEDEVICE_API preboard_error_t preboard_receive_with_timeout(preboard_cli
 	return res;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_receive(preboard_client_t client, plist_t * plist)
+preboard_error_t preboard_receive(preboard_client_t client, plist_t * plist)
 {
 	return preboard_receive_with_timeout(client, plist, 5000);
 }
@@ -208,7 +208,7 @@ static preboard_error_t preboard_receive_status_loop_with_callback(preboard_clie
 	return res;
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_create_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data)
+preboard_error_t preboard_create_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data)
 {
 	if (!client) {
 		return PREBOARD_E_INVALID_ARG;
@@ -231,7 +231,7 @@ LIBIMOBILEDEVICE_API preboard_error_t preboard_create_stashbag(preboard_client_t
 	return preboard_receive_status_loop_with_callback(client, status_cb, user_data);
 }
 
-LIBIMOBILEDEVICE_API preboard_error_t preboard_commit_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data)
+preboard_error_t preboard_commit_stashbag(preboard_client_t client, plist_t manifest, preboard_status_cb_t status_cb, void *user_data)
 {
 	if (!client) {
 		return PREBOARD_E_INVALID_ARG;

--- a/src/property_list_service.c
+++ b/src/property_list_service.c
@@ -58,7 +58,7 @@ static property_list_service_error_t service_to_property_list_service_error(serv
 	return PROPERTY_LIST_SERVICE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client)
+property_list_service_error_t property_list_service_client_new(idevice_t device, lockdownd_service_descriptor_t service, property_list_service_client_t *client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
 		return PROPERTY_LIST_SERVICE_E_INVALID_ARG;
@@ -78,7 +78,7 @@ LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_
 	return PROPERTY_LIST_SERVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_client_free(property_list_service_client_t client)
+property_list_service_error_t property_list_service_client_free(property_list_service_client_t client)
 {
 	if (!client)
 		return PROPERTY_LIST_SERVICE_E_INVALID_ARG;
@@ -152,12 +152,12 @@ static property_list_service_error_t internal_plist_send(property_list_service_c
 	return res;
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist)
+property_list_service_error_t property_list_service_send_xml_plist(property_list_service_client_t client, plist_t plist)
 {
 	return internal_plist_send(client, plist, 0);
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist)
+property_list_service_error_t property_list_service_send_binary_plist(property_list_service_client_t client, plist_t plist)
 {
 	return internal_plist_send(client, plist, 1);
 }
@@ -262,24 +262,24 @@ static property_list_service_error_t internal_plist_receive_timeout(property_lis
 	return res;
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout)
+property_list_service_error_t property_list_service_receive_plist_with_timeout(property_list_service_client_t client, plist_t *plist, unsigned int timeout)
 {
 	return internal_plist_receive_timeout(client, plist, timeout);
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist)
+property_list_service_error_t property_list_service_receive_plist(property_list_service_client_t client, plist_t *plist)
 {
 	return internal_plist_receive_timeout(client, plist, 30000);
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client)
+property_list_service_error_t property_list_service_enable_ssl(property_list_service_client_t client)
 {
 	if (!client || !client->parent)
 		return PROPERTY_LIST_SERVICE_E_INVALID_ARG;
 	return service_to_property_list_service_error(service_enable_ssl(client->parent));
 }
 
-LIBIMOBILEDEVICE_API property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client)
+property_list_service_error_t property_list_service_disable_ssl(property_list_service_client_t client)
 {
 	if (!client || !client->parent)
 		return PROPERTY_LIST_SERVICE_E_INVALID_ARG;

--- a/src/restore.c
+++ b/src/restore.c
@@ -111,7 +111,7 @@ static restored_error_t restored_error(property_list_service_error_t err)
         return RESTORE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_client_free(restored_client_t client)
+restored_error_t restored_client_free(restored_client_t client)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;
@@ -139,7 +139,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_client_free(restored_client_t cli
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API void restored_client_set_label(restored_client_t client, const char *label)
+void restored_client_set_label(restored_client_t client, const char *label)
 {
 	if (client) {
 		if (client->label)
@@ -149,7 +149,7 @@ LIBIMOBILEDEVICE_API void restored_client_set_label(restored_client_t client, co
 	}
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_receive(restored_client_t client, plist_t *plist)
+restored_error_t restored_receive(restored_client_t client, plist_t *plist)
 {
 	if (!client || !plist || (plist && *plist))
 		return RESTORE_E_INVALID_ARG;
@@ -157,7 +157,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_receive(restored_client_t client,
 	return restored_error(property_list_service_receive_plist(client->parent, plist));
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_send(restored_client_t client, plist_t plist)
+restored_error_t restored_send(restored_client_t client, plist_t plist)
 {
 	if (!client || !plist)
 		return RESTORE_E_INVALID_ARG;
@@ -165,7 +165,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_send(restored_client_t client, pl
 	return restored_error(property_list_service_send_xml_plist(client->parent, plist));
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version)
+restored_error_t restored_query_type(restored_client_t client, char **type, uint64_t *version)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;
@@ -224,7 +224,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_query_type(restored_client_t clie
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value)
+restored_error_t restored_query_value(restored_client_t client, const char *key, plist_t *value)
 {
 	if (!client || !key)
 		return RESTORE_E_INVALID_ARG;
@@ -266,7 +266,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_query_value(restored_client_t cli
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value)
+restored_error_t restored_get_value(restored_client_t client, const char *key, plist_t *value)
 {
 	if (!client || !value || (value && *value))
 		return RESTORE_E_INVALID_ARG;
@@ -293,7 +293,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_get_value(restored_client_t clien
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label)
+restored_error_t restored_client_new(idevice_t device, restored_client_t *client, const char *label)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;
@@ -337,7 +337,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_client_new(idevice_t device, rest
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_goodbye(restored_client_t client)
+restored_error_t restored_goodbye(restored_client_t client)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;
@@ -369,7 +369,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_goodbye(restored_client_t client)
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version)
+restored_error_t restored_start_restore(restored_client_t client, plist_t options, uint64_t version)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;
@@ -393,7 +393,7 @@ LIBIMOBILEDEVICE_API restored_error_t restored_start_restore(restored_client_t c
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API restored_error_t restored_reboot(restored_client_t client)
+restored_error_t restored_reboot(restored_client_t client)
 {
 	if (!client)
 		return RESTORE_E_INVALID_ARG;

--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -79,7 +79,7 @@ static sbservices_error_t sbservices_error(property_list_service_error_t err)
 	return SBSERVICES_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client)
+sbservices_error_t sbservices_client_new(idevice_t device, lockdownd_service_descriptor_t service, sbservices_client_t *client)
 {
 	property_list_service_client_t plistclient = NULL;
 	sbservices_error_t err = sbservices_error(property_list_service_client_new(device, service, &plistclient));
@@ -95,14 +95,14 @@ LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_new(idevice_t device, 
 	return SBSERVICES_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t * client, const char* label)
+sbservices_error_t sbservices_client_start_service(idevice_t device, sbservices_client_t * client, const char* label)
 {
 	sbservices_error_t err = SBSERVICES_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, SBSERVICES_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(sbservices_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_free(sbservices_client_t client)
+sbservices_error_t sbservices_client_free(sbservices_client_t client)
 {
 	if (!client)
 		return SBSERVICES_E_INVALID_ARG;
@@ -115,7 +115,7 @@ LIBIMOBILEDEVICE_API sbservices_error_t sbservices_client_free(sbservices_client
 	return err;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version)
+sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist_t *state, const char *format_version)
 {
 	if (!client || !client->parent || !state)
 		return SBSERVICES_E_INVALID_ARG;
@@ -155,7 +155,7 @@ leave_unlock:
 	return res;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate)
+sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist_t newstate)
 {
 	if (!client || !client->parent || !newstate)
 		return SBSERVICES_E_INVALID_ARG;
@@ -181,7 +181,7 @@ LIBIMOBILEDEVICE_API sbservices_error_t sbservices_set_icon_state(sbservices_cli
 	return res;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize)
+sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, const char *bundleId, char **pngdata, uint64_t *pngsize)
 {
 	if (!client || !client->parent || !bundleId || !pngdata)
 		return SBSERVICES_E_INVALID_ARG;
@@ -218,7 +218,7 @@ leave_unlock:
 	return res;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation)
+sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t client, sbservices_interface_orientation_t* interface_orientation)
 {
 	if (!client || !client->parent || !interface_orientation)
 		return SBSERVICES_E_INVALID_ARG;
@@ -256,7 +256,7 @@ leave_unlock:
 	return res;
 }
 
-LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize)
+sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize)
 {
 	if (!client || !client->parent || !pngdata)
 		return SBSERVICES_E_INVALID_ARG;

--- a/src/screenshotr.c
+++ b/src/screenshotr.c
@@ -65,7 +65,7 @@ static screenshotr_error_t screenshotr_error(device_link_service_error_t err)
 	return SCREENSHOTR_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service,
+screenshotr_error_t screenshotr_client_new(idevice_t device, lockdownd_service_descriptor_t service,
 					   screenshotr_client_t * client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
@@ -93,14 +93,14 @@ LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_new(idevice_t device
 	return ret;
 }
 
-LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t * client, const char* label)
+screenshotr_error_t screenshotr_client_start_service(idevice_t device, screenshotr_client_t * client, const char* label)
 {
 	screenshotr_error_t err = SCREENSHOTR_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, SCREENSHOTR_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(screenshotr_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_free(screenshotr_client_t client)
+screenshotr_error_t screenshotr_client_free(screenshotr_client_t client)
 {
 	if (!client)
 		return SCREENSHOTR_E_INVALID_ARG;
@@ -110,7 +110,7 @@ LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_client_free(screenshotr_cli
 	return err;
 }
 
-LIBIMOBILEDEVICE_API screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize)
+screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize)
 {
 	if (!client || !client->parent || !imgdata)
 		return SCREENSHOTR_E_INVALID_ARG;

--- a/src/service.c
+++ b/src/service.c
@@ -56,7 +56,7 @@ static service_error_t idevice_to_service_error(idevice_error_t err)
 	return SERVICE_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client)
+service_error_t service_client_new(idevice_t device, lockdownd_service_descriptor_t service, service_client_t *client)
 {
 	if (!device || !service || service->port == 0 || !client || *client)
 		return SERVICE_E_INVALID_ARG;
@@ -80,7 +80,7 @@ LIBIMOBILEDEVICE_API service_error_t service_client_new(idevice_t device, lockdo
 	return SERVICE_E_SUCCESS;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code)
+service_error_t service_client_factory_start_service(idevice_t device, const char* service_name, void **client, const char* label, int32_t (*constructor_func)(idevice_t, lockdownd_service_descriptor_t, void**), int32_t *error_code)
 {
 	*client = NULL;
 
@@ -119,7 +119,7 @@ LIBIMOBILEDEVICE_API service_error_t service_client_factory_start_service(idevic
 	return (ec == SERVICE_E_SUCCESS) ? SERVICE_E_SUCCESS : SERVICE_E_START_SERVICE_ERROR;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_client_free(service_client_t client)
+service_error_t service_client_free(service_client_t client)
 {
 	if (!client)
 		return SERVICE_E_INVALID_ARG;
@@ -132,7 +132,7 @@ LIBIMOBILEDEVICE_API service_error_t service_client_free(service_client_t client
 	return err;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_send(service_client_t client, const char* data, uint32_t size, uint32_t *sent)
+service_error_t service_send(service_client_t client, const char* data, uint32_t size, uint32_t *sent)
 {
 	service_error_t res = SERVICE_E_UNKNOWN_ERROR;
 	uint32_t bytes = 0;
@@ -153,7 +153,7 @@ LIBIMOBILEDEVICE_API service_error_t service_send(service_client_t client, const
 	return res;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_receive_with_timeout(service_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
+service_error_t service_receive_with_timeout(service_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
 {
 	service_error_t res = SERVICE_E_UNKNOWN_ERROR;
 	uint32_t bytes = 0;
@@ -174,24 +174,24 @@ LIBIMOBILEDEVICE_API service_error_t service_receive_with_timeout(service_client
 	return res;
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_receive(service_client_t client, char* data, uint32_t size, uint32_t *received)
+service_error_t service_receive(service_client_t client, char* data, uint32_t size, uint32_t *received)
 {
 	return service_receive_with_timeout(client, data, size, received, 30000);
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_enable_ssl(service_client_t client)
+service_error_t service_enable_ssl(service_client_t client)
 {
 	if (!client || !client->connection)
 		return SERVICE_E_INVALID_ARG;
 	return idevice_to_service_error(idevice_connection_enable_ssl(client->connection));
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_disable_ssl(service_client_t client)
+service_error_t service_disable_ssl(service_client_t client)
 {
 	return service_disable_bypass_ssl(client, 0);
 }
 
-LIBIMOBILEDEVICE_API service_error_t service_disable_bypass_ssl(service_client_t client, uint8_t sslBypass)
+service_error_t service_disable_bypass_ssl(service_client_t client, uint8_t sslBypass)
 {
 	if (!client || !client->connection)
 		return SERVICE_E_INVALID_ARG;

--- a/src/syslog_relay.c
+++ b/src/syslog_relay.c
@@ -67,7 +67,7 @@ static syslog_relay_error_t syslog_relay_error(service_error_t err)
 	return SYSLOG_RELAY_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client)
+syslog_relay_error_t syslog_relay_client_new(idevice_t device, lockdownd_service_descriptor_t service, syslog_relay_client_t * client)
 {
 	*client = NULL;
 
@@ -95,14 +95,14 @@ LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_new(idevice_t devi
 	return 0;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label)
+syslog_relay_error_t syslog_relay_client_start_service(idevice_t device, syslog_relay_client_t * client, const char* label)
 {
 	syslog_relay_error_t err = SYSLOG_RELAY_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, SYSLOG_RELAY_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(syslog_relay_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client)
+syslog_relay_error_t syslog_relay_client_free(syslog_relay_client_t client)
 {
 	if (!client)
 		return SYSLOG_RELAY_E_INVALID_ARG;
@@ -113,12 +113,12 @@ LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_client_free(syslog_relay_
 	return err;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char* data, uint32_t size, uint32_t *received)
+syslog_relay_error_t syslog_relay_receive(syslog_relay_client_t client, char* data, uint32_t size, uint32_t *received)
 {
 	return syslog_relay_receive_with_timeout(client, data, size, received, 1000);
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
+syslog_relay_error_t syslog_relay_receive_with_timeout(syslog_relay_client_t client, char* data, uint32_t size, uint32_t *received, unsigned int timeout)
 {
 	syslog_relay_error_t res = SYSLOG_RELAY_E_UNKNOWN_ERROR;
 	int bytes = 0;
@@ -176,7 +176,7 @@ void *syslog_relay_worker(void *arg)
 	return NULL;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data)
+syslog_relay_error_t syslog_relay_start_capture(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data)
 {
 	if (!client || !callback)
 		return SYSLOG_RELAY_E_INVALID_ARG;
@@ -204,7 +204,7 @@ LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture(syslog_rela
 	return res;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture_raw(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data)
+syslog_relay_error_t syslog_relay_start_capture_raw(syslog_relay_client_t client, syslog_relay_receive_cb_t callback, void* user_data)
 {
 	if (!client || !callback)
 		return SYSLOG_RELAY_E_INVALID_ARG;
@@ -232,7 +232,7 @@ LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_start_capture_raw(syslog_
 	return res;
 }
 
-LIBIMOBILEDEVICE_API syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client)
+syslog_relay_error_t syslog_relay_stop_capture(syslog_relay_client_t client)
 {
 	if (client->worker) {
 		/* notify thread to finish */

--- a/src/webinspector.c
+++ b/src/webinspector.c
@@ -62,7 +62,7 @@ static webinspector_error_t webinspector_error(property_list_service_error_t err
 	return WEBINSPECTOR_E_UNKNOWN_ERROR;
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client)
+webinspector_error_t webinspector_client_new(idevice_t device, lockdownd_service_descriptor_t service, webinspector_client_t * client)
 {
 	*client = NULL;
 
@@ -89,14 +89,14 @@ LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_new(idevice_t devi
 	return 0;
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label)
+webinspector_error_t webinspector_client_start_service(idevice_t device, webinspector_client_t * client, const char* label)
 {
 	webinspector_error_t err = WEBINSPECTOR_E_UNKNOWN_ERROR;
 	service_client_factory_start_service(device, WEBINSPECTOR_SERVICE_NAME, (void**)client, label, SERVICE_CONSTRUCTOR(webinspector_client_new), &err);
 	return err;
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_free(webinspector_client_t client)
+webinspector_error_t webinspector_client_free(webinspector_client_t client)
 {
 	if (!client)
 		return WEBINSPECTOR_E_INVALID_ARG;
@@ -107,7 +107,7 @@ LIBIMOBILEDEVICE_API webinspector_error_t webinspector_client_free(webinspector_
 	return err;
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist)
+webinspector_error_t webinspector_send(webinspector_client_t client, plist_t plist)
 {
 	webinspector_error_t res = WEBINSPECTOR_E_UNKNOWN_ERROR;
 
@@ -164,12 +164,12 @@ LIBIMOBILEDEVICE_API webinspector_error_t webinspector_send(webinspector_client_
 	return res;
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist)
+webinspector_error_t webinspector_receive(webinspector_client_t client, plist_t * plist)
 {
 	return webinspector_receive_with_timeout(client, plist, 5000);
 }
 
-LIBIMOBILEDEVICE_API webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms)
+webinspector_error_t webinspector_receive_with_timeout(webinspector_client_t client, plist_t * plist, uint32_t timeout_ms)
 {
 	webinspector_error_t res = WEBINSPECTOR_E_UNKNOWN_ERROR;
 	plist_t message = NULL;


### PR DESCRIPTION
clang + lld + ucrt on Windows seems to require that the dllimport
attribute be applied to the first declaration.

Fixes -Wdll-attribute-on-declaration error.

Signed-off-by: Rosen Penev <rosenp@gmail.com>