### PR TITLE
Fixed DEBUGSERVER_SECURE_SERVICE_NAME macro

### DIFF
--- a/include/libimobiledevice/debugserver.h
+++ b/include/libimobiledevice/debugserver.h
@@ -31,7 +31,7 @@ extern "C" {
 #include <libimobiledevice/lockdown.h>
 
 #define DEBUGSERVER_SERVICE_NAME "com.apple.debugserver"
-#define DEBUGSERVER_SECURE_SERVICE_NAME DEBUGSERVER_SERVICE_NAME ".DVTSecureSocketProxy"
+#define DEBUGSERVER_SECURE_SERVICE_NAME "com.apple.debugserver.DVTSecureSocketProxy"
 
 /** Error Codes */
 typedef enum {


### PR DESCRIPTION
secure service name shady, which causes SSL connections (idevicedebug) to always fail. Fixed it with this.