### PR TITLE
Update mobilesync version to support iOS 14

### DIFF
--- a/src/mobilesync.c
+++ b/src/mobilesync.c
@@ -34,7 +34,7 @@
 #include "device_link_service.h"
 #include "common/debug.h"
 
-#define MSYNC_VERSION_INT1 300
+#define MSYNC_VERSION_INT1 400
 #define MSYNC_VERSION_INT2 100
 
 #define EMPTY_PARAMETER_STRING "___EmptyParameterString___"


### PR DESCRIPTION
Mobilesync does not work for iOS 14. It fails with error message as `MOBILESYNC_E_BAD_VERSION`.

Changing the MSYNC_VERSION_INT1 to 400 would solve this issue.