### PR TITLE
idevicecrashreport windows file names

### DIFF
--- a/tools/idevicecrashreport.c
+++ b/tools/idevicecrashreport.c
@@ -148,6 +148,14 @@ static int afc_client_copy_and_remove_crash_reports(afc_client_t afc, const char
 		strcpy(((char*)source_filename) + device_directory_length, list[k]);
 
 		/* assemble absolute target filename */
+#ifdef WIN32
+		// replace every ':' with '-' since ':' is an illegal character for file names in windows
+		char* current_pos = strchr(list[k], ':');
+		while (current_pos) {
+			*current_pos = '-';
+			current_pos = strchr(current_pos, ':');
+		}
+#endif
 		char* p = strrchr(list[k], '.');
 		if (p != NULL && !strncmp(p, ".synced", 7)) {
 			/* make sure to strip ".synced" extension as seen on iOS 5 */

--- a/tools/idevicecrashreport.c
+++ b/tools/idevicecrashreport.c
@@ -149,7 +149,7 @@ static int afc_client_copy_and_remove_crash_reports(afc_client_t afc, const char
 
 		/* assemble absolute target filename */
 #ifdef WIN32
-		// replace every ':' with '-' since ':' is an illegal character for file names in windows
+		/* replace every ':' with '-' since ':' is an illegal character for file names in windows */
 		char* current_pos = strchr(list[k], ':');
 		while (current_pos) {
 			*current_pos = '-';


### PR DESCRIPTION
Some files cannot be extracted on windows since they contain `:` in their name (mostly seen as part of a date format such as `hh:mm:ss` as part of the file name).

This is a small patch to make sure we don't miss those files.