### PR TITLE
The problem of memory release in Win32

### DIFF
--- a/include/libimobiledevice/sbservices.h
+++ b/include/libimobiledevice/sbservices.h
@@ -169,6 +169,17 @@ sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t clie
  */
 sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
 
+
+/*
+ * Release the memory data returned by sbservices_get_home_screen_wallpaper_pngdata()
+ *
+ * @param pngdata The image memory address returned by sbservices_get_home_screen_wallpaper_pngdata().
+ *
+ * @return none.
+ * */
+void sbservices_free_screen_wallpaper_image_data(char* pngdata);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libimobiledevice/screenshotr.h
+++ b/include/libimobiledevice/screenshotr.h
@@ -110,6 +110,16 @@ screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
  */
 screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
 
+
+/*
+ * Release the memory data returned by screenshotr_take_screenshot()
+ *
+ * @param imgdata The image memory address returned by screenshotr_take_screenshot().
+ *
+ * @return none.
+ * */
+void screenshotr_free_screenshot_image_data(char* imgdata);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -291,3 +291,9 @@ leave_unlock:
 	sbservices_unlock(client);
 	return res;
 }
+
+LIBIMOBILEDEVICE_API void sbservices_free_screen_wallpaper_image_data(char* pngdata){
+	if(pngdata){
+		free(pngdata);
+	}
+}

--- a/src/screenshotr.c
+++ b/src/screenshotr.c
@@ -163,3 +163,9 @@ leave:
 
 	return res;
 }
+
+LIBIMOBILEDEVICE_API void screenshotr_free_screenshot_image_data(char* imgdata){
+	if(imgdata){
+		free(imgdata);
+	}
+}


### PR DESCRIPTION
On windows, we can't freely release the memory applied by other dynamic libraries.

So I add an interface to release the memory of screen capture application.