### PR TITLE
Added missing dependencies for idevicepair.

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -41,8 +41,8 @@ idevicename_LDFLAGS = $(AM_LDFLAGS)
 idevicename_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicepair_SOURCES = idevicepair.c
-idevicepair_CFLAGS = $(AM_CFLAGS) $(ssl_lib_CFLAGS)
-idevicepair_LDFLAGS = $(AM_LDFLAGS) $(libusbmuxd_LIBS) $(ssl_lib_LIBS)
+idevicepair_CFLAGS = $(AM_CFLAGS) $(ssl_lib_CFLAGS) $(limd_glue_CFLAGS)
+idevicepair_LDFLAGS = $(AM_LDFLAGS) $(libusbmuxd_LIBS) $(ssl_lib_LIBS) $(limd_glue_LIBS)
 idevicepair_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la
 
 idevicesyslog_SOURCES = idevicesyslog.c


### PR DESCRIPTION
The build on my system was failing with:

/usr/bin/ld: ../src/.libs/libimobiledevice-1.0.so: undefined reference to symbol 'string_concat'
/usr/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../lib/libimobiledevice-glue-1.0.so: error adding symbols: DSO missing from command line
...
make[2]: *** [Makefile:762: idevicepair] Error 1

After adding the new glue code to the C and LD flags the project now build correctly.