### PR TITLE
Win32: add MSVC compatible call

### DIFF
--- a/include/libimobiledevice/debugserver.h
+++ b/include/libimobiledevice/debugserver.h
@@ -234,6 +234,14 @@ debugserver_error_t debugserver_command_free(debugserver_command_t command);
  */
 void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32_t* encoded_length);
 
+
+/**
+ * Release the encode string created by debugserver_encode_string
+ *
+ * @param ncoded_buffer Encoding string of debugserver_encode_string request
+ */
+void debugserver_encode_string_free(char* encoded_buffer);
+
 /**
  * Decodes a hex encoded string.
  *
@@ -242,6 +250,14 @@ void debugserver_encode_string(const char* buffer, char** encoded_buffer, uint32
  * @param buffer Decoded string to be freed by the caller
  */
 void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer);
+
+
+/**
+ * Release the decode string created by debugserver_decode_string
+ *
+ * @param buffer Decoding string of debugserver_decode_string request
+ */
+void debugserver_decode_string_free(char* buffer);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/sbservices.h
+++ b/include/libimobiledevice/sbservices.h
@@ -159,7 +159,7 @@ sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t clie
  * @param client The connected sbservices client to use.
  * @param pngdata Pointer that will point to a newly allocated buffer
  *     containing the PNG data upon successful return. It is up to the caller
- *     to free the memory.
+ *     to sbservices_get_home_screen_wallpaper_pngdata_free the memory.
  * @param pngsize Pointer to a uint64_t that will be set to the size of the
  *     buffer pngdata points to upon successful return.
  *
@@ -168,6 +168,13 @@ sbservices_error_t sbservices_get_interface_orientation(sbservices_client_t clie
  *     code otherwise.
  */
 sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
+
+/**
+ * Release screen wallpaper data requested by sbservices_get_home_screen_wallpaper_pngdata
+ *
+ * @param pngdata Pointer to screen wallpaper PNG data
+ */
+void sbservices_get_home_screen_wallpaper_pngdata_free(char *pngdata);
 
 #ifdef __cplusplus
 }

--- a/include/libimobiledevice/screenshotr.h
+++ b/include/libimobiledevice/screenshotr.h
@@ -100,7 +100,7 @@ screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
  * @param client The connection screenshotr service client.
  * @param imgdata Pointer that will point to a newly allocated buffer
  *     containing TIFF image data upon successful return. It is up to the
- *     caller to free the memory.
+ *     caller to screenshotr_take_screenshot_free the memory.
  * @param imgsize Pointer to a uint64_t that will be set to the size of the
  *     buffer imgdata points to upon successful return.
  *
@@ -109,6 +109,13 @@ screenshotr_error_t screenshotr_client_free(screenshotr_client_t client);
  *     error occurred.
  */
 screenshotr_error_t screenshotr_take_screenshot(screenshotr_client_t client, char **imgdata, uint64_t *imgsize);
+
+/**
+ * Release screenshot data requested by screenshotr_take_screenshot
+ *
+ * @param imgdata Pointer to TIFF image data
+ */
+void screenshotr_take_screenshot_free(char *imgdata);
 
 #ifdef __cplusplus
 }

--- a/src/debugserver.c
+++ b/src/debugserver.c
@@ -284,6 +284,11 @@ LIBIMOBILEDEVICE_API void debugserver_encode_string(const char* buffer, char** e
 	}
 }
 
+void debugserver_encode_string_free(char* encoded_buffer)
+{
+    free(encoded_buffer);
+}
+
 LIBIMOBILEDEVICE_API void debugserver_decode_string(const char *encoded_buffer, size_t encoded_length, char** buffer)
 {
 	*buffer = malloc(sizeof(char) * ((encoded_length / 2)+1));
@@ -295,6 +300,11 @@ LIBIMOBILEDEVICE_API void debugserver_decode_string(const char *encoded_buffer, 
 		f += 2;
 	}
 	*t = '\0';
+}
+
+void debugserver_decode_string_free(char* buffer)
+{
+    free(buffer);
 }
 
 static void debugserver_format_command(const char* prefix, const char* command, const char* arguments, int calculate_checksum, char** buffer, uint32_t* size)

--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -291,3 +291,8 @@ leave_unlock:
 	sbservices_unlock(client);
 	return res;
 }
+
+void sbservices_get_home_screen_wallpaper_pngdata_free(char *pngdata)
+{
+    free(pngdata);
+}

--- a/src/screenshotr.c
+++ b/src/screenshotr.c
@@ -163,3 +163,8 @@ leave:
 
 	return res;
 }
+
+void screenshotr_take_screenshot_free(char *imgdata)
+{
+    free(imgdata);
+}


### PR DESCRIPTION
This PR is similar to some release methods added by libplist.
On windows, exceptions occur when memory is released across dynamic libraries, especially different compilers.