### PR TITLE
Fix error is not redirect to stderr

### DIFF
--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -211,9 +211,9 @@ int main(int argc, char *argv[])
 	ret = idevice_new_with_options(&device, udid, (use_network) ? IDEVICE_LOOKUP_NETWORK : IDEVICE_LOOKUP_USBMUX);
 	if (ret != IDEVICE_E_SUCCESS) {
 		if (udid) {
-			printf("ERROR: Device %s not found!\n", udid);
+			fprintf(stderr, "ERROR: Device %s not found!\n", udid);
 		} else {
-			printf("ERROR: No device found!\n");
+			fprintf(stderr, "ERROR: No device found!\n");
 		}
 		return -1;
 	}


### PR DESCRIPTION
Fix error is not redirect to `stderr`
 - Like `idevicename` (see [this line](https://github.com/libimobiledevice/libimobiledevice/blob/master/tools/idevicename.c#L115) and [this line](https://github.com/libimobiledevice/libimobiledevice/blob/master/tools/idevicename.c#L117)), `ideviceinfo` should also redirect error to `stderr`

## How to reproduce
1. Run `$ ideviceinfo --udid "whatever-non-existing-udid" 2> /dev/null`
2. Check `ERROR: Device whatever-non-existing-udid not found!` is printed even though `2> /dev/null` is specified.

**Command and Output**
```shell
$ ideviceinfo --udid "whatever-non-existing-udid" 2> /dev/null
ERROR: Device whatever-non-existing-udid not found!
```

## Expected behavior
1. Run `$ ideviceinfo --udid "whatever-non-existing-udid" 2> /dev/null`
2. Check nothing is printed as we redirect `stderr` to `/dev/null`

**Command and Output**
```shell
$ ideviceinfo --udid "whatever-non-existing-udid" 2> /dev/null
(print nothing because stderr is redirected to /dev/null)
```