### PR TITLE
Use synchronous mode when callbacks are NULL

### DIFF
--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -663,7 +663,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_install(instproxy_client_t clie
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "PackagePath", plist_new_string(pkg_path));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 
@@ -680,7 +680,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_upgrade(instproxy_client_t clie
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "PackagePath", plist_new_string(pkg_path));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 
@@ -697,7 +697,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_uninstall(instproxy_client_t cl
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "ApplicationIdentifier", plist_new_string(appid));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 
@@ -730,7 +730,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_archive(instproxy_client_t clie
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "ApplicationIdentifier", plist_new_string(appid));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 
@@ -747,7 +747,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_restore(instproxy_client_t clie
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "ApplicationIdentifier", plist_new_string(appid));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 
@@ -764,7 +764,7 @@ LIBIMOBILEDEVICE_API instproxy_error_t instproxy_remove_archive(instproxy_client
 		plist_dict_set_item(command, "ClientOptions", plist_copy(client_options));
 	plist_dict_set_item(command, "ApplicationIdentifier", plist_new_string(appid));
 
-	res = instproxy_perform_command(client, command, INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
+	res = instproxy_perform_command(client, command, status_cb == NULL ? INSTPROXY_COMMAND_TYPE_SYNC : INSTPROXY_COMMAND_TYPE_ASYNC, status_cb, user_data);
 
 	plist_free(command);
 


### PR DESCRIPTION
Synchronous modes for `instproxy_install`, `instproxy_upgrade`, `instproxy_uninstall`, `instproxy_archive`, `instproxy_restore`, and `instproxy_remove_archive` appear to be ignoring the documented behavior that “If NULL is passed, this function will run synchronously”.