### PR TITLE
Fix typo in docblock

### DIFF
--- a/include/libimobiledevice/mobilebackup2.h
+++ b/include/libimobiledevice/mobilebackup2.h
@@ -156,7 +156,7 @@ mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, cons
  * @param data Pointer to a buffer that will be filled with the received data.
  * @param length Number of bytes to receive. The data buffer needs to be large
  *     enough to store this amount of data.
- * @paran bytes Number of bytes actually received.
+ * @param bytes Number of bytes actually received.
  *
  * @return MOBILEBACKUP2_E_SUCCESS if any or no data was received,
  *     MOBILEBACKUP2_E_INVALID_ARG if one of the parameters is invalid,


### PR DESCRIPTION
This PR fixes a typo in the docblock of `mobilebackup2_receive_raw`. Without this patch the current docs are missing a proper description of the `bytes` parameter (see [here](https://docs.libimobiledevice.org/libimobiledevice/latest/mobilebackup2_8h_a27469291309887a60abbbafd1d90eac3.html#a27469291309887a60abbbafd1d90eac3))