### PR TITLE
partial fix for --password option

### DIFF
--- a/tools/idevicebackup2.c
+++ b/tools/idevicebackup2.c
@@ -1521,7 +1521,7 @@ int main(int argc, char *argv[])
 		{ "settings", no_argument, NULL, OPT_SETTINGS },
 		{ "remove", no_argument, NULL, OPT_REMOVE },
 		{ "skip-apps", no_argument, NULL, OPT_SKIP_APPS },
-		{ "password", no_argument, NULL, OPT_PASSWORD },
+		{ "password", required_argument, NULL, OPT_PASSWORD },
 		{ "full", no_argument, NULL, OPT_FULL },
 		{ NULL, 0, NULL, 0}
 	};


### PR DESCRIPTION
Right now, you can not do encrypted backups using `idevicebackup2`, because of a segfault [here](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L1593)

Despite what the documentation says :

- you can not provide a password via `BACKUP_PASSWORD` / `BACKUP_PASSWORD_NEW` environment variables, because those are only used if `is_encrypted` is True, which is the case only if `cmd == CMD_RESTORE || cmd == CMD_UNBACK`, and not if `cmd == CMD_BACKUP` ([ref](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L1770))
- you can not provide a password via `-i`, because the interactive mode is only used if `is_encrypted` is True ([ref](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L1800))
- you can not provide a password via command line, because of a mistake in the configuration, causing `backup_password = strdup(optarg);` to segfault ([ref](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L1593))
- the `willEncrypt` boolean is not taken into account if a password is not provided, although [a comment](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L2018) seems to mention that this is a TODO.

The PR only fixes the command line option, as i'm not familiar enough with the code to patch [this whole section](https://github.com/libimobiledevice/libimobiledevice/blob/dec0438c89a020995229b08aeaee96c403c5daed/tools/idevicebackup2.c#L1770-L1796).