### PR TITLE
Allow manual modification of Lockdownd pairing directory: for Android

### DIFF
--- a/common/userpref.c
+++ b/common/userpref.c
@@ -148,6 +148,18 @@ static char *userpref_utf16_to_utf8(wchar_t *unistr, long len, long *items_read,
 }
 #endif
 
+void userpref_set_config_dir(const char* directory)
+{
+	if(__config_dir) {
+		free(__config_dir);
+		__config_dir = NULL;
+	}
+	if(directory) {
+		__config_dir = strdup(directory);
+		debug_info("modify config_dir to %s", __config_dir);
+	}
+}
+
 const char *userpref_get_config_dir()
 {
 	char *base_config_dir = NULL;

--- a/common/userpref.h
+++ b/common/userpref.h
@@ -62,6 +62,7 @@ typedef enum {
 	USERPREF_E_UNKNOWN_ERROR = -256
 } userpref_error_t;
 
+void userpref_set_config_dir(const char* directory);
 const char *userpref_get_config_dir(void);
 int userpref_read_system_buid(char **system_buid);
 userpref_error_t userpref_read_pair_record(const char *udid, plist_t *pair_record);

--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -100,6 +100,13 @@ typedef struct idevice_subscription_context* idevice_subscription_context_t;
 /* functions */
 
 /**
+ * Set the Lockdownd pairing directory.
+ *
+ * @param directory The specified new Lockdownd pairing directory.
+ */
+void idevice_set_pairing_directory(const char* directory);
+
+/**
  * Set the level of debugging.
  *
  * @param level Set to 0 for no debug output or 1 to enable debug output.

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -401,6 +401,11 @@ LIBIMOBILEDEVICE_API idevice_error_t idevice_device_list_free(char **devices)
 	return IDEVICE_E_SUCCESS;
 }
 
+LIBIMOBILEDEVICE_API void idevice_set_pairing_directory(const char* directory)
+{
+	userpref_set_config_dir(directory);
+}
+
 LIBIMOBILEDEVICE_API void idevice_set_debug_level(int level)
 {
 	internal_set_debug_level(level);


### PR DESCRIPTION
In Android, we need java to transfer a readable and writable directory.