### PR TITLE
Compatible with Windows Dll memory release boundary

### DIFF
--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -107,6 +107,13 @@ typedef struct idevice_subscription_context* idevice_subscription_context_t;
 void idevice_set_debug_level(int level);
 
 /**
+ * Release the memory requested by libimobiledevice
+ *
+ * @param memory Memory requested by libimobiledevice.
+ * */
+void imobiledevice_mem_free(void* memory);
+
+/**
  * Subscribe a callback function that will be called when device add/remove
  * events occur.
  *

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -406,6 +406,11 @@ LIBIMOBILEDEVICE_API void idevice_set_debug_level(int level)
 	internal_set_debug_level(level);
 }
 
+LIBIMOBILEDEVICE_API void imobiledevice_mem_free(void* memory)
+{
+	free(memory);
+}
+
 static idevice_t idevice_from_mux_device(usbmuxd_device_info_t *muxdev)
 {
 	if (!muxdev)


### PR DESCRIPTION
Due to the boundary problem of Windows Dll, the dynamic library follows the principle of "who applies, who free".