### PR TITLE
Make a task to enable to keep forks in sync

### DIFF
--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -1,0 +1,18 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.4
+        with:
+          owner: libimobiledevice
+          base: master
+          head: master

--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -2,12 +2,12 @@ name: Sync Fork
 
 on:
   schedule:
-    - cron: '*/30 * * * *' # every 30 minutes
+    - cron: '0 8 * * *' # Daily
   workflow_dispatch: # on button click
 
 jobs:
   sync:
-
+    if: github.repository_owner != 'libimobiledevice' # Only on forks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since LIMD has few contributors, forks are key, this is a scheduled task to ensure forks are kept up to date