### PR TITLE
Fix iOS build

### DIFF
--- a/3rd_party/libsrp6a-sha512/Makefile.am
+++ b/3rd_party/libsrp6a-sha512/Makefile.am
@@ -9,7 +9,7 @@ include_HEADERS = srp.h srp_aux.h cstr.h
 
 AM_CFLAGS = -DHAVE_CONFIG_H
 if HAVE_OPENSSL
-AM_CFLAGS += -DOPENSSL=1 -DOPENSSL_ENGINE=1 $(openssl_CFLAGS)
+AM_CFLAGS += -DOPENSSL=1 $(openssl_CFLAGS)
 else
 if HAVE_GCRYPT
 AM_CFLAGS += -DGCRYPT=1 $(libgcrypt_CFLAGS)

--- a/3rd_party/libsrp6a-sha512/t_math.c
+++ b/3rd_party/libsrp6a-sha512/t_math.c
@@ -39,7 +39,8 @@ typedef BIGNUM * BigInteger;
 typedef BN_CTX * BigIntegerCtx;
 typedef BN_MONT_CTX * BigIntegerModAccel;
 #include <limits.h>
-# ifdef OPENSSL_ENGINE
+# ifndef OPENSSL_NO_ENGINE
+#  define OPENSSL_ENGINE
 #  include "openssl/engine.h"
 static ENGINE * default_engine = NULL;
 # endif /* OPENSSL_ENGINE */
@@ -951,7 +952,7 @@ BigIntegerModAccelFree(accel)
 BigIntegerResult
 BigIntegerInitialize()
 {
-#if OPENSSL_VERSION_NUMBER >= 0x00907000
+#if OPENSSL_VERSION_NUMBER >= 0x00907000 && defined(OPENSSL_ENGINE)
   ENGINE_load_builtin_engines();
 #endif
   return BIG_INTEGER_SUCCESS;

--- a/git-version-gen
+++ b/git-version-gen
@@ -3,7 +3,7 @@ SRCDIR=`dirname $0`
 if test -n "$1"; then
   VER=$1
 else
-  if test -d "${SRCDIR}/.git" && test -x "`which git`" ; then
+  if test -r "${SRCDIR}/.git" && test -x "`which git`" ; then
     git update-index -q --refresh
     if ! VER=`git describe --tags --dirty 2>/dev/null`; then
       COMMIT=`git rev-parse --short HEAD`

--- a/src/lockdown-cu.c
+++ b/src/lockdown-cu.c
@@ -62,6 +62,7 @@
 #include <sys/sysctl.h>
 #include <SystemConfiguration/SystemConfiguration.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <TargetConditionals.h>
 #endif
 
 #include "property_list_service.h"
@@ -647,7 +648,7 @@ LIBIMOBILEDEVICE_API lockdownd_error_t lockdownd_cu_pairing_create(lockdownd_cli
 
 			/* HOST INFORMATION */
 			char hostname[256];
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(TARGET_OS_IPHONE)
 			CFStringRef cname = SCDynamicStoreCopyComputerName(NULL, NULL);
 			CFStringGetCString(cname, hostname, sizeof(hostname), kCFStringEncodingUTF8);
 			CFRelease(cname);


### PR DESCRIPTION
This PR includes three orthogonal changes that fix building for iOS:

- Allow using limd as a submodule (relevant to use cases where limd is inside a parent project)
- Support OpenSSL built without OPENSSL_ENGINE (the [most popular](https://github.com/krzyzanowskim/OpenSSL) OpenSSL dist for iOS is built with `OPENSSL_NO_ENGINE`)
- Don't try to use `SCDynamicStoreCopyComputerName` on iOS – it's only defined in the macOS SDK.