### PR TITLE
Add libimobiledevice-glue CFLAGS to idevicerepair

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -47,7 +47,7 @@ idevicename_LDFLAGS = $(AM_LDFLAGS)
 idevicename_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la
 
 idevicepair_SOURCES = idevicepair.c
-idevicepair_CFLAGS = $(AM_CFLAGS) $(ssl_lib_CFLAGS)
+idevicepair_CFLAGS = $(AM_CFLAGS) $(ssl_lib_CFLAGS) $(limd_glue_CFLAGS)
 idevicepair_LDFLAGS = $(AM_LDFLAGS) $(libusbmuxd_LIBS) $(ssl_lib_LIBS)
 idevicepair_LDADD = $(top_builddir)/src/libimobiledevice-1.0.la $(top_builddir)/common/libinternalcommon.la $(limd_glue_LIBS)
 


### PR DESCRIPTION
Running `./autogen.sh --prefix /opt/local --enable-debug` failes with:

```
idevicepair.c:44:10: fatal error: 'libimobiledevice-glue/utils.h' file not found
#include <libimobiledevice-glue/utils.h>
```

This PR adds `$(limd_glue_CFLAGS)`  to `idevicepair_CFLAGS`