### PR TITLE
Add timeout option for mobilebackup2_receive_message

### DIFF
--- a/include/libimobiledevice/mobilebackup2.h
+++ b/include/libimobiledevice/mobilebackup2.h
@@ -128,6 +128,27 @@ mobilebackup2_error_t mobilebackup2_send_message(mobilebackup2_client_t client, 
 mobilebackup2_error_t mobilebackup2_receive_message(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage);
 
 /**
+ * Receives a DL* message plist from the device with the specified timeout.
+ * This function is a wrapper around device_link_service_receive_message_with_timeout.
+ *
+ * @param client The connected MobileBackup client to use.
+ * @param msg_plist Pointer to a plist that will be set to the contents of the
+ *    message plist upon successful return.
+ * @param dlmessage A pointer that will be set to a newly allocated char*
+ *     containing the DL* string from the given plist. It is up to the caller
+ *     to free the allocated memory. If this parameter is NULL
+ *     it will be ignored.
+ * @param timeout_ms Timeout in milliseconds
+ *
+ * @return MOBILEBACKUP2_E_SUCCESS if a DL* message was received,
+ *    MOBILEBACKUP2_E_INVALID_ARG if client or message is invalid,
+ *    MOBILEBACKUP2_E_PLIST_ERROR if the received plist is invalid
+ *    or is not a DL* message plist, or MOBILEBACKUP2_E_MUX_ERROR if
+ *    receiving from the device failed.
+ */
+mobilebackup2_error_t mobilebackup2_receive_message_with_timeout(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage, uint32_t timeout_ms);
+
+/**
  * Send binary data to the device.
  *
  * @note This function returns MOBILEBACKUP2_E_SUCCESS even if less than the

--- a/src/device_link_service.c
+++ b/src/device_link_service.c
@@ -359,11 +359,34 @@ device_link_service_error_t device_link_service_send_process_message(device_link
  */
 device_link_service_error_t device_link_service_receive_message(device_link_service_client_t client, plist_t *msg_plist, char **dlmessage)
 {
+	return device_link_service_receive_message_with_timeout(client, msg_plist, dlmessage, 30000);
+}
+
+/**
+ * Receives a DL* message plist with the specified timeout.
+ *
+ * @param client The connected device link service client used for receiving.
+ * @param msg_plist Pointer to a plist that will be set to the contents of the
+ *    message plist upon successful return.
+ * @param dlmessage A pointer that will be set to a newly allocated char*
+ *     containing the DL* string from the given plist. It is up to the caller
+ *     to free the allocated memory. If this parameter is NULL
+ *     it will be ignored.
+ * @param timeout_ms Timeout in milliseconds
+ *
+ * @return DEVICE_LINK_SERVICE_E_SUCCESS if a DL* message was received,
+ *    DEVICE_LINK_SERVICE_E_INVALID_ARG if client or message is invalid,
+ *    DEVICE_LINK_SERVICE_E_PLIST_ERROR if the received plist is invalid
+ *    or is not a DL* message plist, or DEVICE_LINK_SERVICE_E_MUX_ERROR if
+ *    receiving from the device failed.
+ */
+device_link_service_error_t device_link_service_receive_message_with_timeout(device_link_service_client_t client, plist_t *msg_plist, char **dlmessage, uint32_t timeout_ms)
+{
 	if (!client || !client->parent || !msg_plist)
 		return DEVICE_LINK_SERVICE_E_INVALID_ARG;
 
 	*msg_plist = NULL;
-	device_link_service_error_t err = device_link_error(property_list_service_receive_plist(client->parent, msg_plist));
+	device_link_service_error_t err = device_link_error(property_list_service_receive_plist_with_timeout(client->parent, msg_plist, timeout_ms));
 	if (err != DEVICE_LINK_SERVICE_E_SUCCESS) {
 		return err;
 	}

--- a/src/device_link_service.h
+++ b/src/device_link_service.h
@@ -47,6 +47,7 @@ device_link_service_error_t device_link_service_client_free(device_link_service_
 device_link_service_error_t device_link_service_version_exchange(device_link_service_client_t client, uint64_t version_major, uint64_t version_minor);
 device_link_service_error_t device_link_service_send_ping(device_link_service_client_t client, const char *message);
 device_link_service_error_t device_link_service_receive_message(device_link_service_client_t client, plist_t *msg_plist, char **dlmessage);
+device_link_service_error_t device_link_service_receive_message_with_timeout(device_link_service_client_t client, plist_t *msg_plist, char **dlmessage, uint32_t timeout_ms);
 device_link_service_error_t device_link_service_send_process_message(device_link_service_client_t client, plist_t message);
 device_link_service_error_t device_link_service_receive_process_message(device_link_service_client_t client, plist_t *message);
 device_link_service_error_t device_link_service_disconnect(device_link_service_client_t client, const char *message);

--- a/src/mobilebackup2.c
+++ b/src/mobilebackup2.c
@@ -219,6 +219,11 @@ LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_message(mobileb
 	return mobilebackup2_error(device_link_service_receive_message(client->parent, msg_plist, dlmessage));
 }
 
+LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_receive_message_with_timeout(mobilebackup2_client_t client, plist_t *msg_plist, char **dlmessage, uint32_t timeout_ms)
+{
+	return mobilebackup2_error(device_link_service_receive_message_with_timeout(client->parent, msg_plist, dlmessage, timeout_ms));
+}
+
 LIBIMOBILEDEVICE_API mobilebackup2_error_t mobilebackup2_send_raw(mobilebackup2_client_t client, const char *data, uint32_t length, uint32_t *bytes)
 {
 	if (!client || !client->parent || !data || (length == 0) || !bytes)


### PR DESCRIPTION
Sometimes we may need to respond quickly, and the original 30-second waiting time is too long.
A new interface is added that allows the caller to customize the timeout period.