### PR TITLE
Fix mobilebackup compile err

### DIFF
--- a/src/mobilebackup.c
+++ b/src/mobilebackup.c
@@ -26,6 +26,7 @@
 #include <plist/plist.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "mobilebackup.h"
 #include "device_link_service.h"


### PR DESCRIPTION
The build fails on OSX when gnutls chosen as a TLS backend, make complains about missing `sscanf` decalration.

```bash
./autogen.sh --without-cython --with-gnutls
make
```

> Making all in src
>   CC       mobilebackup.lo
> mobilebackup.c:284:4: error: implicitly declaring library function 'sscanf' with type 'int (const char *restrict, const char *restrict, ...)' [-Werror,-Wimplicit-function-declaration]
>                         sscanf(str, "%u.%u", &maj, &min);
>                         ^
> mobilebackup.c:284:4: note: include the header <stdio.h> or explicitly provide a declaration for 'sscanf'
> 1 error generated.
> make[2]: *** [mobilebackup.lo] Error 1
> make[1]: *** [all-recursive] Error 1