### PR TITLE
Remove bashisms in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ AC_ARG_WITH([mbedtls],
             [Do not look for mbedtls])],
             [use_mbedtls=$withval],
             [use_mbedtls=no])
-if test "x$use_mbedtls" == "xyes"; then
+if test "x$use_mbedtls" = "xyes"; then
   default_openssl=no
 fi
 AC_ARG_WITH([gnutls],
@@ -173,7 +173,7 @@ AC_ARG_WITH([gnutls],
             [Do not look for GnuTLS])],
             [use_gnutls=$withval],
             [use_gnutls=no])
-if test "x$use_gnutls" == "xyes"; then
+if test "x$use_gnutls" = "xyes"; then
   default_openssl=no
 fi
 AC_ARG_WITH([openssl],
@@ -182,7 +182,7 @@ AC_ARG_WITH([openssl],
             [use_openssl=$withval],
             [use_openssl=$default_openssl])
 
-if test "x$use_mbedtls" == "xyes"; then
+if test "x$use_mbedtls" = "xyes"; then
   CACHED_CFLAGS="$CFLAGS"
   conf_mbedtls_CFLAGS=""
   if test -n "$mbedtls_INCLUDES"; then
@@ -209,7 +209,7 @@ if test "x$use_mbedtls" == "xyes"; then
   ssl_requires=""
   AC_SUBST(ssl_requires)
 else
-  if test "x$use_openssl" == "xyes"; then
+  if test "x$use_openssl" = "xyes"; then
     pkg_req_openssl="openssl >= 0.9.8"
     PKG_CHECK_MODULES(openssl, $pkg_req_openssl, have_openssl=yes, have_openssl=no)
     if test "x$have_openssl" != "xyes"; then
@@ -225,7 +225,7 @@ else
       AC_SUBST(ssl_requires)
     fi
   else
-    if test "x$use_gnutls" == "xyes"; then
+    if test "x$use_gnutls" = "xyes"; then
       pkg_req_gnutls="gnutls >= 2.2.0"
       pkg_req_libtasn1="libtasn1 >= 1.1"
       PKG_CHECK_MODULES(libgnutls, $pkg_req_gnutls)
@@ -246,9 +246,9 @@ else
     fi
   fi
 fi
-AM_CONDITIONAL(HAVE_MBEDTLS, test "x$use_mbedtls" == "xyes")
-AM_CONDITIONAL(HAVE_OPENSSL, test "x$use_openssl" == "xyes")
-AM_CONDITIONAL(HAVE_GCRYPT, test "x$use_gnutls" == "xyes")
+AM_CONDITIONAL(HAVE_MBEDTLS, test "x$use_mbedtls" = "xyes")
+AM_CONDITIONAL(HAVE_OPENSSL, test "x$use_openssl" = "xyes")
+AM_CONDITIONAL(HAVE_GCRYPT, test "x$use_gnutls" = "xyes")
 
 AC_ARG_ENABLE([wireless-pairing],
             [AS_HELP_STRING([--disable-wireless-pairing],


### PR DESCRIPTION
This change fixes the following errors when building from source on systems where /bin/sh is not bash: 
```
$ ./autogen.sh
[...]
./configure: 20360: test: xno: unexpected operator
./configure: 20372: test: xno: unexpected operator
./configure: 20385: test: xno: unexpected operator
./configure: 20421: test: xyes: unexpected operator
./configure: 20509: test: xno: unexpected operator
configure: error: No SSL library configured. libimobiledevice cannot be built without a supported SSL library.
```
