### PR TITLE
include unistd.h for usleep()

### DIFF
--- a/tools/idevicedevmodectl.c
+++ b/tools/idevicedevmodectl.c
@@ -40,6 +40,7 @@
 #define __usleep(x) Sleep(x/1000)
 #else
 #include <arpa/inet.h>
+#include <unistd.h>
 #define __usleep(x) usleep(x)
 #endif
 


### PR DESCRIPTION
clang16 flags the missing header

Fixes
../../git/tools/idevicedevmodectl.c:363:2: error: call to undeclared function 'usleep'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]