### PR TITLE
Read setIconState response

### DIFF
--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -172,7 +172,10 @@ LIBIMOBILEDEVICE_API sbservices_error_t sbservices_set_icon_state(sbservices_cli
 	if (res != SBSERVICES_E_SUCCESS) {
 		debug_info("could not send plist, error %d", res);
 	}
-	/* NO RESPONSE */
+
+	uint32_t bytes = 0;
+	service_receive_with_timeout(client->parent->parent, malloc(4), 4, &bytes, 2000);
+	debug_info("setIconState response: %u", bytes);
 
 	if (dict) {
 		plist_free(dict);


### PR DESCRIPTION
This allows the same connection to be used again after `sbservices_set_icon_state` is called. Similar to https://github.com/facebook/idb/blob/5340a1301bb2542c0ee0c2e11ea347833170995b/FBDeviceControl/Management/FBSpringboardServicesClient.m#L271.

Fixes #928.