### PR TITLE
Fix Cython 3 noexcept compilation error

### DIFF
--- a/cython/imobiledevice.pyx
+++ b/cython/imobiledevice.pyx
@@ -94,7 +94,7 @@ cdef class iDeviceEvent:
         def __get__(self):
             return self._c_event.conn_type
 
-cdef void idevice_event_cb(const_idevice_event_t c_event, void *user_data) with gil:
+cdef void idevice_event_cb(const_idevice_event_t c_event, void *user_data) noexcept:
     cdef iDeviceEvent event = iDeviceEvent.__new__(iDeviceEvent)
     event._c_event = c_event
     (<object>user_data)(event)

--- a/cython/installation_proxy.pxi
+++ b/cython/installation_proxy.pxi
@@ -27,7 +27,7 @@ cdef extern from "libimobiledevice/installation_proxy.h":
     instproxy_error_t instproxy_restore(instproxy_client_t client, char *appid, plist.plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
     instproxy_error_t instproxy_remove_archive(instproxy_client_t client, char *appid, plist.plist_t client_options, instproxy_status_cb_t status_cb, void *user_data)
 
-cdef void instproxy_notify_cb(plist.plist_t command, plist.plist_t status, void *py_callback) with gil:
+cdef void instproxy_notify_cb(plist.plist_t command, plist.plist_t status, void *py_callback) noexcept:
     (<object>py_callback)(plist.plist_t_to_node(command, False), plist.plist_t_to_node(status, False))
 
 cdef class InstallationProxyError(BaseError):

--- a/cython/notification_proxy.pxi
+++ b/cython/notification_proxy.pxi
@@ -70,7 +70,7 @@ NP_ITDBPREP_DID_END = C_NP_ITDBPREP_DID_END
 NP_LANGUAGE_CHANGED = C_NP_LANGUAGE_CHANGED
 NP_ADDRESS_BOOK_PREF_CHANGED = C_NP_ADDRESS_BOOK_PREF_CHANGED
 
-cdef void np_notify_cb(const_char_ptr notification, void *py_callback):
+cdef void np_notify_cb(const_char_ptr notification, void *py_callback) noexcept:
     (<object>py_callback)(notification)
 
 cdef class NotificationProxyError(BaseError):


### PR DESCRIPTION
As reported in [Issue 1515](https://github.com/libimobiledevice/libimobiledevice/issues/1515#issue-2044767417) Cython 3 reports a compilation error due to missing `noexcept` keyword.
This commit fixes it.