### PR TITLE
find libimobiledevice-glue in e.g. /opt/homebrew/

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -7,13 +7,15 @@ AM_CFLAGS = \
 	$(ssl_lib_CFLAGS) \
 	$(LFS_CFLAGS) \
 	$(libusbmuxd_CFLAGS) \
-	$(libplist_CFLAGS)
+	$(libplist_CFLAGS) \
+	$(limd_glue_CFLAGS)
 
 AM_LDFLAGS = \
 	$(ssl_lib_LIBS) \
 	${libpthread_LIBS} \
 	$(libusbmuxd_LIBS) \
-	$(libplist_LIBS)
+	$(libplist_LIBS) \
+	$(limd_glue_LIBS)
 
 noinst_LTLIBRARIES = libinternalcommon.la
 libinternalcommon_la_LIBADD = 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -6,10 +6,12 @@ AM_CFLAGS = \
 	$(GLOBAL_CFLAGS) \
 	$(ssl_lib_CFLAGS) \
 	$(libplist_CFLAGS) \
-	$(LFS_CFLAGS)
+	$(LFS_CFLAGS) \
+	$(limd_glue_CFLAGS)
 
 AM_LDFLAGS = \
-	$(libplist_LIBS)
+	$(libplist_LIBS) \
+	$(limd_glue_LIBS)
 
 bin_PROGRAMS = \
 	idevicebtlogger\


### PR DESCRIPTION
This allows one to build under OSX using xcode 14.2.