### PR TITLE
ideviceinfo: add a new option for printing device info in a file

### DIFF
--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
 			switch (format) {
 			case FORMAT_XML:
 				plist_to_xml(node, &xml_doc, &xml_length);
-				if(c = 'p'){
+				if(c == 'p'){
 					FILE* pathfile = fopen(path, "w");
 					fprintf(pathfile, "%s", xml_doc);
 					fclose(pathfile);
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
 				free(xml_doc);
 				break;
 			case FORMAT_KEY_VALUE:
-				if(c = 'p'){
+				if(c == 'p'){
 					FILE* pathfile = fopen(path, "w");
 					plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
 					fclose(pathfile);

--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -139,6 +139,8 @@ int main(int argc, char *argv[])
 	char *xml_doc = NULL;
 	uint32_t xml_length;
 	plist_t node = NULL;
+	FILE* pathfile = NULL;
+	int pathoption = 0;
 
 	int c = 0;
 	const struct option longopts[] = {
@@ -197,8 +199,9 @@ int main(int argc, char *argv[])
 				print_usage(argc, argv, 1);
 				return 2;
 			}
+			pathoption = 1;
 			path = optarg;
-			printf("Device info will be printed in %s", path);
+			printf("Device info will be printed in %s \n", path);
 			break;
 		case 'x':
 			format = FORMAT_XML;
@@ -249,28 +252,37 @@ int main(int argc, char *argv[])
 			switch (format) {
 			case FORMAT_XML:
 				plist_to_xml(node, &xml_doc, &xml_length);
-				if(c == 'p'){
-					FILE* pathfile = fopen(path, "w");
-					fprintf(pathfile, "%s", xml_doc);
-					fclose(pathfile);
-				}
-				else printf("%s", xml_doc);
+						if(pathoption){
+						 	pathfile = fopen(path, "w");
+							if(pathfile){
+								fprintf(pathfile, "%s", xml_doc);
+								fclose(pathfile);
+								printf("Device info is printed successfully.\n");
+							}
+						}
+						else printf("%s", xml_doc);
 				free(xml_doc);
 				break;
 			case FORMAT_KEY_VALUE:
-				if(c == 'p'){
-					FILE* pathfile = fopen(path, "w");
-					plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
-					fclose(pathfile);
-				}
-				else plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+						if(pathoption){
+							pathfile = fopen(path, "w");
+							if(pathfile){
+								plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
+								fclose(pathfile);
+								printf("Device info is printed successfully.\n");
+							}
+						}
+						else plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
 				break;
 			default:
 				if (key != NULL){
-					if(c == 'p'){
-						FILE* pathfile = fopen(path, "w");
-						plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
-						fclose(pathfile);
+					if(pathoption){
+						pathfile = fopen(path, "w");
+						if(pathfile){
+							plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+							fclose(pathfile);
+							printf("Device info is printed successfully.\n");
+						}
 					}
 					else plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
 				}

--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
 				break;
 			default:
 				if (key != NULL){
-					if(c = 'p'){
+					if(c == 'p'){
 						FILE* pathfile = fopen(path, "w");
 						plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
 						fclose(pathfile);

--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -135,6 +135,7 @@ int main(int argc, char *argv[])
 	int use_network = 0;
 	const char *domain = NULL;
 	const char *key = NULL;
+	const char *path = NULL;
 	char *xml_doc = NULL;
 	uint32_t xml_length;
 	plist_t node = NULL;
@@ -191,39 +192,13 @@ int main(int argc, char *argv[])
 			key = optarg;
 			break;
 		case 'p':
-			// if (LOCKDOWN_E_SUCCESS != (ldret = simple ?
-			// lockdownd_client_new(device, &client, TOOL_NAME):
-			// lockdownd_client_new_with_handshake(device, &client, TOOL_NAME))) {
-			// 	fprintf(stderr, "ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(ldret), ldret);
-			// 	idevice_free(device);
-			// 	return -1;
-			// }
-			// if(lockdownd_get_value(client, domain, key, &node) == LOCKDOWN_E_SUCCESS) {
-			// 	if (node) {
-			// 		FILE* pathfile = fopen(argv[2],"w");
-			// 		switch (format) {
-			// 		case FORMAT_XML:
-			// 			plist_to_xml(node, &xml_doc, &xml_length);
-			// 			fprintf(pathfile, "%s", xml_doc);
-			// 			free(xml_doc);
-			// 			fclose(pathfile);
-			// 			break;
-			// 		case FORMAT_KEY_VALUE:
-			// 			plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
-			// 			break;
-			// 		default:
-			// 			if (key != NULL){
-			// 				plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
-			// 			}
-			// 			break;
-			// 		}
-			// 		plist_free(node);
-			// 		node = NULL;
-			// 		fclose(pathfile);
-			// 	}
-			// 	return 0;
-			// }
-			printf("Device info will be printed in %s",argv[2]);
+			if (!*optarg){
+				fprintf(stderr, "ERROR: 'path' must not be empty!\n");
+				print_usage(argc, argv, 1);
+				return 2;
+			}
+			path = optarg;
+			printf("Device info will be printed in %s", path);
 			break;
 		case 'x':
 			format = FORMAT_XML;
@@ -275,7 +250,7 @@ int main(int argc, char *argv[])
 			case FORMAT_XML:
 				plist_to_xml(node, &xml_doc, &xml_length);
 				if(c = 'p'){
-					FILE* pathfile = fopen(argv[2],"w");
+					FILE* pathfile = fopen(path, "w");
 					fprintf(pathfile, "%s", xml_doc);
 					fclose(pathfile);
 				}
@@ -284,7 +259,7 @@ int main(int argc, char *argv[])
 				break;
 			case FORMAT_KEY_VALUE:
 				if(c = 'p'){
-					FILE* pathfile = fopen(argv[2],"w");
+					FILE* pathfile = fopen(path, "w");
 					plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
 					fclose(pathfile);
 				}
@@ -293,7 +268,7 @@ int main(int argc, char *argv[])
 			default:
 				if (key != NULL){
 					if(c = 'p'){
-						FILE* pathfile = fopen(argv[2],"w");
+						FILE* pathfile = fopen(path, "w");
 						plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
 						fclose(pathfile);
 					}

--- a/tools/ideviceinfo.c
+++ b/tools/ideviceinfo.c
@@ -191,38 +191,39 @@ int main(int argc, char *argv[])
 			key = optarg;
 			break;
 		case 'p':
-			if (LOCKDOWN_E_SUCCESS != (ldret = simple ?
-			lockdownd_client_new(device, &client, TOOL_NAME):
-			lockdownd_client_new_with_handshake(device, &client, TOOL_NAME))) {
-				fprintf(stderr, "ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(ldret), ldret);
-				idevice_free(device);
-				return -1;
-			}
-			if(lockdownd_get_value(client, domain, key, &node) == LOCKDOWN_E_SUCCESS) {
-				if (node) {
-					FILE* pathfile = fopen(argv[2],"w");
-					switch (format) {
-					case FORMAT_XML:
-						plist_to_xml(node, &xml_doc, &xml_length);
-						fprintf(pathfile, "%s", xml_doc);
-						free(xml_doc);
-						fclose(pathfile);
-						break;
-					case FORMAT_KEY_VALUE:
-						plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
-						break;
-					default:
-						if (key != NULL){
-							plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
-						}
-						break;
-					}
-					plist_free(node);
-					node = NULL;
-					fclose(pathfile);
-				}
-				return 0;
-			}
+			// if (LOCKDOWN_E_SUCCESS != (ldret = simple ?
+			// lockdownd_client_new(device, &client, TOOL_NAME):
+			// lockdownd_client_new_with_handshake(device, &client, TOOL_NAME))) {
+			// 	fprintf(stderr, "ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(ldret), ldret);
+			// 	idevice_free(device);
+			// 	return -1;
+			// }
+			// if(lockdownd_get_value(client, domain, key, &node) == LOCKDOWN_E_SUCCESS) {
+			// 	if (node) {
+			// 		FILE* pathfile = fopen(argv[2],"w");
+			// 		switch (format) {
+			// 		case FORMAT_XML:
+			// 			plist_to_xml(node, &xml_doc, &xml_length);
+			// 			fprintf(pathfile, "%s", xml_doc);
+			// 			free(xml_doc);
+			// 			fclose(pathfile);
+			// 			break;
+			// 		case FORMAT_KEY_VALUE:
+			// 			plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
+			// 			break;
+			// 		default:
+			// 			if (key != NULL){
+			// 				plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
+			// 			}
+			// 			break;
+			// 		}
+			// 		plist_free(node);
+			// 		node = NULL;
+			// 		fclose(pathfile);
+			// 	}
+			// 	return 0;
+			// }
+			printf("Device info will be printed in %s",argv[2]);
 			break;
 		case 'x':
 			format = FORMAT_XML;
@@ -273,15 +274,31 @@ int main(int argc, char *argv[])
 			switch (format) {
 			case FORMAT_XML:
 				plist_to_xml(node, &xml_doc, &xml_length);
-				printf("%s", xml_doc);
+				if(c = 'p'){
+					FILE* pathfile = fopen(argv[2],"w");
+					fprintf(pathfile, "%s", xml_doc);
+					fclose(pathfile);
+				}
+				else printf("%s", xml_doc);
 				free(xml_doc);
 				break;
 			case FORMAT_KEY_VALUE:
-				plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+				if(c = 'p'){
+					FILE* pathfile = fopen(argv[2],"w");
+					plist_write_to_stream(node, pathfile, PLIST_FORMAT_LIMD, 0);
+					fclose(pathfile);
+				}
+				else plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
 				break;
 			default:
-				if (key != NULL)
-					plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+				if (key != NULL){
+					if(c = 'p'){
+						FILE* pathfile = fopen(argv[2],"w");
+						plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+						fclose(pathfile);
+					}
+					else plist_write_to_stream(node, stdout, PLIST_FORMAT_LIMD, 0);
+				}
 			break;
 			}
 			plist_free(node);


### PR DESCRIPTION
Hello,

In this pull request, I added a new option to the ideviceinfo program: a -p option, allowing you to print device information to a file on your computer. You can choose the file name just after the -p option in your command, like this:

```
ideviceinfo -p ~/Desktop/hello.txt
```

will print device information in a new file called ```hello.txt``` in your Desktop.

It also works with other options, like

```
ideviceinfo -x -p  ~/Desktop/hello.txt
```

will print device information in XML format in a new file called ```hello.txt``` in your Desktop.