### PR TITLE
Makefile doesn't compile documentation on first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,4 +203,4 @@ iPadOS, tvOS, watchOS, and macOS are trademarks of Apple Inc.
 This project is an independent software and has not been authorized, sponsored,
 or otherwise approved by Apple Inc.
 
-README Updated on: 2023-12-30
+README Updated on: 2024-10-08

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ MbedTLS headers and `mbedtls_LIBDIR` to set the library path. Optionally,
 ./autogen.sh --with-mbedtls mbedtls_INCLUDES=/opt/local/include mbedtls_LIBDIR=/opt/local/lib
 ```
 
+If you need the documentation and it wasn't build after installation, tap
+```
+make docs
+```
+or
+```
+doxygen doxygen.cfg
+```
+
 ## Usage
 
 Documentation about using the library in your application is not available yet.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ MbedTLS headers and `mbedtls_LIBDIR` to set the library path. Optionally,
 ./autogen.sh --with-mbedtls mbedtls_INCLUDES=/opt/local/include mbedtls_LIBDIR=/opt/local/lib
 ```
 
-If you need the documentation and it wasn't build after installation, tap
+If you need to use the documentation and does not compile after compilation / installation, tap
 ```
 make docs
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ MbedTLS headers and `mbedtls_LIBDIR` to set the library path. Optionally,
 ./autogen.sh --with-mbedtls mbedtls_INCLUDES=/opt/local/include mbedtls_LIBDIR=/opt/local/lib
 ```
 
-If you need to use the documentation and does not compile after compilation / installation, tap
+If you need to use the documentation and doesn't build after compilation / installation, tap
 ```
 make docs
 ```


### PR DESCRIPTION
Hello,

When I launch make command for libimobiledevice, it compiles everything but not the docs. I should launch manually ```make docs``` or ```doxygen doxygen.cfg``` after, and the documentation compiles successfully. I precise this information on the README file.