### PR TITLE
common/userpref: remove X509V3_EXT_cleanup()

### DIFF
--- a/common/userpref.c
+++ b/common/userpref.c
@@ -627,7 +627,6 @@ userpref_error_t pair_record_generate_keys_and_certs(plist_t pair_record, key_da
 		}
 	}
 
-	X509V3_EXT_cleanup();
 	X509_free(dev_cert);
 
 	EVP_PKEY_free(pubkey);


### PR DESCRIPTION
When building libimobiledevice with libressl 3.9 it fails with an implicit declaration for `X509V3_EXT_cleanup()`.

This was removed in libressl "because it was part of a dangerous, incomplete and mostly useless API".

Additionally it doesn't seem to be actually used by libimobiledevice:

"It cleans up the stack containing custom extensions which libimobiledevice doesn't use, it's only needed after calls to X509V3_EXT_add{,_list,_alias}()."

Reference: https://github.com/libressl/portable/issues/1050