### PR TITLE
libsrp6a-sha512: disable BN_mod_exp_mont_word() with LibreSSL

### DIFF
--- a/3rd_party/libsrp6a-sha512/t_math.c
+++ b/3rd_party/libsrp6a-sha512/t_math.c
@@ -720,7 +720,11 @@ BigIntegerModExp(BigInteger r, BigInteger b, BigInteger e, BigInteger m, BigInte
   else if(a == NULL) {
     BN_mod_exp(r, b, e, m, c);
   }
-#if OPENSSL_VERSION_NUMBER >= 0x00906000
+/*
+ * In LibreSSL BN_mod_exp_mont_word() is not a public symbol where BN_mod_exp()
+ * and BN_mod_exp_mont() will use the word optimization when appropriate.
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x00906000 && !defined(LIBRESSL_VERSION_NUMBER)
   else if(B > 0 && B < ULONG_MAX) {  /* 0.9.6 and above has mont_word optimization */
     BN_mod_exp_mont_word(r, B, e, m, c, a);
   }


### PR DESCRIPTION
When building libimobiledevice with LibreSSL 3.9 it fails with an implicit declaration for `BN_mod_exp_mont_word()`.

This function was removed from the public symbols in LibreSSL because it is rarely used where "BN_mod_exp() and BN_mod_exp_mont() will use the word optimization when appropriate."

Reference: https://github.com/libressl/portable/issues/1049