### PR TITLE
Allow get/put folders from/to devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ docs/html
 libimobiledevice-1.0.pc
 tools/.libs/*
 tools/idevice*
+tools/afcclient
 !tools/idevice*.[ch]
 cython/.libs/*
 cython/*.c

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -18,7 +18,8 @@ man_MANS = \
 	idevicedebug.1 \
 	idevicedevmodectl.1 \
 	idevicenotificationproxy.1 \
-	idevicesetlocation.1
+	idevicesetlocation.1 \
+	afcclient.1
 
 EXTRA_DIST = $(man_MANS)
 

--- a/docs/afcclient.1
+++ b/docs/afcclient.1
@@ -32,16 +32,14 @@ create directory at PATH
 .B ln [-s] FILE [LINK]
 Create a (symbolic) link to file named LINKNAME. \f[B]NOTE: This feature has been disabled in newer versions of iOS\f[].
 .TP
-.B rm PATH
+.B rm [-rf] PATH
 remove item at PATH
 .TP
-.B get PATH [LOCALPATH]
+.B get [-rf] PATH [LOCALPATH]
 transfer file at PATH from device to LOCALPATH, or current directory if omitted. If LOCALPATH is a directory, the file will be stored inside the directory.
-\f[B]WARNING\f[]: Existing files will be overwritten!
 .TP
-.B put LOCALPATH [PATH]
+.B put [-rf] LOCALPATH [PATH]
 transfer local file at LOCALPATH to device at PATH, or current directory if omitted. If PATH is a directory, the file will be stored inside the directory.
-\f[B]WARNING\f[]: Existing files will be overwritten!
 .TP
 
 .SH OPTIONS

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -1006,7 +1006,6 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 			}
 		}
 	}
-	printf("\n");
 	free(buf);
 	afc_file_close(afc, fh);
 	fclose(f);

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -193,8 +193,8 @@ static void handle_help(afc_client_t afc, int argc, char** argv)
 	printf("ln [-s] FILE [LINK] - create a (symbolic) link to file named LINKNAME\n");
 	printf("        NOTE: This feature has been disabled in newer versions of iOS.\n");
 	printf("rm PATH - remove item at PATH\n");
-	printf("get PATH [LOCALPATH] - transfer file at PATH from device to LOCALPATH\n");
-	printf("put LOCALPATH [PATH] - transfer local file at LOCALPATH to device at PATH\n");
+	printf("get [-rf] PATH [LOCALPATH] - transfer file at PATH from device to LOCALPATH\n");
+	printf("put [-rf] LOCALPATH [PATH] - transfer local file at LOCALPATH to device at PATH\n");
 	printf("\n");
 }
 

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -91,13 +91,13 @@ static idevice_subscription_context_t context = NULL;
 static char* curdir = NULL;
 static size_t curdir_len = 0;
 
-static int is_directory(const char* path)
+static int is_directory(const char *path)
 {
-    struct stat tst;
+	struct stat tst;
 #ifdef WIN32
-    return (stat(path, &tst) == 0) && S_ISDIR(tst.st_mode);
+	return (stat(path, &tst) == 0) && S_ISDIR(tst.st_mode);
 #else
-    return (lstat(path, &tst) == 0) && S_ISDIR(tst.st_mode);
+	return (lstat(path, &tst) == 0) && S_ISDIR(tst.st_mode);
 #endif
 }
 
@@ -688,395 +688,475 @@ static void handle_remove(afc_client_t afc, int argc, char** argv)
 
 static uint8_t get_single_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint64_t file_size)
 {
-    uint64_t fh = 0;
-    afc_error_t err = afc_file_open(afc, srcpath, AFC_FOPEN_RDONLY, &fh);
-    if (err != AFC_E_SUCCESS) {
-        printf("Error: Failed to open file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
-        return 0;
-    }
-    FILE *f = fopen(dstpath, "wb");
-    if (!f) {
-        printf("Error: Failed to open local file '%s': %s\n", dstpath, strerror(errno));
-        return 0;
-    }
-    struct timeval t1;
-    struct timeval t2;
-    struct timeval tdiff;
-    size_t bufsize = 0x100000;
-    char *buf = malloc(bufsize);
-    size_t total = 0;
-    int progress = 0;
-    int lastprog = 0;
-    if (file_size > 0x400000) {
-        progress = 1;
-        gettimeofday(&t1, NULL);
-    }
-    uint8_t succeed = 1;
-    while (err == AFC_E_SUCCESS) {
-        uint32_t bytes_read = 0;
-        size_t chunk = 0;
-        err = afc_file_read(afc, fh, buf, bufsize, &bytes_read);
-        if (bytes_read == 0) {
-            break;
-        }
-        while (chunk < bytes_read) {
-            size_t wr = fwrite(buf + chunk, 1, bytes_read - chunk, f);
-            if (wr == 0) {
-                if (progress) {
-                    printf("\n");
-                }
-                printf("Error: Failed to write to local file\n");
-                succeed = 0;
-                break;
-            }
-            chunk += wr;
-        }
-        total += chunk;
-        if (progress) {
-            int prog = (int) ((double) total / (double) file_size * 100.0f);
-            if (prog > lastprog) {
-                gettimeofday(&t2, NULL);
-                timeval_subtract(&tdiff, &t2, &t1);
-                double time_in_sec = (double) tdiff.tv_sec + (double) tdiff.tv_usec / 1000000;
-                printf("\r%d%% (%0.1f MB/s)   ", prog, (double) total / 1048576.0f / time_in_sec);
-                fflush(stdout);
-                lastprog = prog;
-            }
-        }
-    }
-    if (progress) {
-        printf("\n");
-    }
-    if (err != AFC_E_SUCCESS) {
-        printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
-        succeed = 0;
-    }
-    free(buf);
-    fclose(f);
-    afc_file_close(afc, fh);
-    return succeed;
+	uint64_t fh = 0;
+	afc_error_t err = afc_file_open(afc, srcpath, AFC_FOPEN_RDONLY, &fh);
+	if (err != AFC_E_SUCCESS)
+	{
+		printf("Error: Failed to open file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		return 0;
+	}
+	FILE *f = fopen(dstpath, "wb");
+	if (!f)
+	{
+		printf("Error: Failed to open local file '%s': %s\n", dstpath, strerror(errno));
+		return 0;
+	}
+	struct timeval t1;
+	struct timeval t2;
+	struct timeval tdiff;
+	size_t bufsize = 0x100000;
+	char *buf = malloc(bufsize);
+	size_t total = 0;
+	int progress = 0;
+	int lastprog = 0;
+	if (file_size > 0x400000)
+	{
+		progress = 1;
+		gettimeofday(&t1, NULL);
+	}
+	uint8_t succeed = 1;
+	while (err == AFC_E_SUCCESS)
+	{
+		uint32_t bytes_read = 0;
+		size_t chunk = 0;
+		err = afc_file_read(afc, fh, buf, bufsize, &bytes_read);
+		if (bytes_read == 0)
+		{
+			break;
+		}
+		while (chunk < bytes_read)
+		{
+			size_t wr = fwrite(buf + chunk, 1, bytes_read - chunk, f);
+			if (wr == 0)
+			{
+				if (progress)
+				{
+					printf("\n");
+				}
+				printf("Error: Failed to write to local file\n");
+				succeed = 0;
+				break;
+			}
+			chunk += wr;
+		}
+		total += chunk;
+		if (progress)
+		{
+			int prog = (int)((double)total / (double)file_size * 100.0f);
+			if (prog > lastprog)
+			{
+				gettimeofday(&t2, NULL);
+				timeval_subtract(&tdiff, &t2, &t1);
+				double time_in_sec = (double)tdiff.tv_sec + (double)tdiff.tv_usec / 1000000;
+				printf("\r%d%% (%0.1f MB/s)   ", prog, (double)total / 1048576.0f / time_in_sec);
+				fflush(stdout);
+				lastprog = prog;
+			}
+		}
+	}
+	if (progress)
+	{
+		printf("\n");
+	}
+	if (err != AFC_E_SUCCESS)
+	{
+		printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		succeed = 0;
+	}
+	free(buf);
+	fclose(f);
+	afc_file_close(afc, fh);
+	return succeed;
 }
 
 static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpath)
 {
-    char **info = NULL;
-    uint64_t file_size = 0;
-    afc_error_t err = afc_get_file_info(afc, srcpath, &info);
-    if (err == AFC_E_OBJECT_NOT_FOUND) {
-        printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
-        return 0;
-    }
-    uint8_t is_dir = 0;
-    if (info) {
-        char **p = info;
-        while (p && *p) {
-            if (!strcmp(*p, "st_size")) {
-                p++;
-                file_size = (uint64_t) strtoull(*p, NULL, 10);
-            }
-            if (!strcmp(*p, "st_ifmt")) {
-                p++;
-                is_dir = !strcmp(*p, "S_IFDIR");
-            }
-            p++;
-        }
-        afc_dictionary_free(info);
-    }
-    uint8_t succeed = 1;
-    if (is_dir) {
-        char **entries = NULL;
-        err = afc_read_directory(afc, srcpath, &entries);
-        if (err != AFC_E_SUCCESS) {
-            printf("Error: Failed to list '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
-            return 0;
-        }
-        char **p = entries;
-        size_t srcpath_len = strlen(srcpath);
-        int srcpath_is_root = strcmp(srcpath, "/") == 0;
-        if (!is_directory(dstpath) && mkdir(dstpath, 0777) != 0) {
-            printf("Error: Failed to create folder '%s': %s\n", dstpath, strerror(errno));
-            afc_dictionary_free(entries);
-            return 0;
-        }
-        while (p && *p) {
-            if (strcmp(".", *p) == 0 || strcmp("..", *p) == 0) {
-                p++;
-                continue;
-            }
-            size_t len = srcpath_len + 1 + strlen(*p) + 1;
-            char *testpath = (char *) malloc(len);
-            if (srcpath_is_root) {
-                snprintf(testpath, len, "/%s", *p);
-            } else {
-                snprintf(testpath, len, "%s/%s", srcpath, *p);
-            }
-            size_t dst_len = strlen(dstpath) + 1 + strlen(*p) + 1;
-            char *newdst = (char *) malloc(dst_len);
-            snprintf(newdst, dst_len, "%s/%s", dstpath, *p);
-            if (!get_file(afc, testpath, newdst)) {
-                succeed = 0;
-                break;
-            }
-            free(testpath);
-            free(newdst);
-            p++;
-        }
-        afc_dictionary_free(entries);
-    } else {
-        succeed = get_single_file(afc, srcpath, dstpath, file_size);
-    }
-    return succeed;
+	char **info = NULL;
+	uint64_t file_size = 0;
+	afc_error_t err = afc_get_file_info(afc, srcpath, &info);
+	if (err == AFC_E_OBJECT_NOT_FOUND)
+	{
+		printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		return 0;
+	}
+	uint8_t is_dir = 0;
+	if (info)
+	{
+		char **p = info;
+		while (p && *p)
+		{
+			if (!strcmp(*p, "st_size"))
+			{
+				p++;
+				file_size = (uint64_t)strtoull(*p, NULL, 10);
+			}
+			if (!strcmp(*p, "st_ifmt"))
+			{
+				p++;
+				is_dir = !strcmp(*p, "S_IFDIR");
+			}
+			p++;
+		}
+		afc_dictionary_free(info);
+	}
+	uint8_t succeed = 1;
+	if (is_dir)
+	{
+		char **entries = NULL;
+		err = afc_read_directory(afc, srcpath, &entries);
+		if (err != AFC_E_SUCCESS)
+		{
+			printf("Error: Failed to list '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+			return 0;
+		}
+		char **p = entries;
+		size_t srcpath_len = strlen(srcpath);
+		int srcpath_is_root = strcmp(srcpath, "/") == 0;
+		if (!is_directory(dstpath) && mkdir(dstpath, 0777) != 0)
+		{
+			printf("Error: Failed to create folder '%s': %s\n", dstpath, strerror(errno));
+			afc_dictionary_free(entries);
+			return 0;
+		}
+		while (p && *p)
+		{
+			if (strcmp(".", *p) == 0 || strcmp("..", *p) == 0)
+			{
+				p++;
+				continue;
+			}
+			size_t len = srcpath_len + 1 + strlen(*p) + 1;
+			char *testpath = (char *)malloc(len);
+			if (srcpath_is_root)
+			{
+				snprintf(testpath, len, "/%s", *p);
+			}
+			else
+			{
+				snprintf(testpath, len, "%s/%s", srcpath, *p);
+			}
+			size_t dst_len = strlen(dstpath) + 1 + strlen(*p) + 1;
+			char *newdst = (char *)malloc(dst_len);
+			snprintf(newdst, dst_len, "%s/%s", dstpath, *p);
+			if (!get_file(afc, testpath, newdst))
+			{
+				succeed = 0;
+				break;
+			}
+			free(testpath);
+			free(newdst);
+			p++;
+		}
+		afc_dictionary_free(entries);
+	}
+	else
+	{
+		succeed = get_single_file(afc, srcpath, dstpath, file_size);
+	}
+	return succeed;
 }
 
 static void handle_get(afc_client_t afc, int argc, char **argv)
 {
-    if (argc < 1 || argc > 2) {
-        printf("Error: Invalid number of arguments\n");
-        return;
-    }
-    char *srcpath = NULL;
-    char *dstpath = NULL;
-    if (argc == 1) {
-        char *tmp = strdup(argv[0]);
-        size_t src_len = strlen(tmp);
-        if (src_len > 1 && tmp[src_len - 1] == '/') {
-            tmp[src_len - 1] = '\0';
-        }
-        srcpath = get_absolute_path(tmp);
-        dstpath = strdup(path_get_basename(tmp));
-        free(tmp);
-    } else {
-        char *tmp = strdup(argv[0]);
-        size_t src_len = strlen(tmp);
-        if (src_len > 1 && tmp[src_len - 1] == '/') {
-            tmp[src_len - 1] = '\0';
-        }
-        srcpath = get_absolute_path(tmp);
-        dstpath = strdup(argv[1]);
-        size_t dst_len = strlen(dstpath);
-        if (dst_len > 1 && dstpath[dst_len - 1] == '/') {
-            dstpath[dst_len - 1] = '\0';
-        }
-        free(tmp);
-    }
+	if (argc < 1 || argc > 2)
+	{
+		printf("Error: Invalid number of arguments\n");
+		return;
+	}
+	char *srcpath = NULL;
+	char *dstpath = NULL;
+	if (argc == 1)
+	{
+		char *tmp = strdup(argv[0]);
+		size_t src_len = strlen(tmp);
+		if (src_len > 1 && tmp[src_len - 1] == '/')
+		{
+			tmp[src_len - 1] = '\0';
+		}
+		srcpath = get_absolute_path(tmp);
+		dstpath = strdup(path_get_basename(tmp));
+		free(tmp);
+	}
+	else
+	{
+		char *tmp = strdup(argv[0]);
+		size_t src_len = strlen(tmp);
+		if (src_len > 1 && tmp[src_len - 1] == '/')
+		{
+			tmp[src_len - 1] = '\0';
+		}
+		srcpath = get_absolute_path(tmp);
+		dstpath = strdup(argv[1]);
+		size_t dst_len = strlen(dstpath);
+		if (dst_len > 1 && dstpath[dst_len - 1] == '/')
+		{
+			dstpath[dst_len - 1] = '\0';
+		}
+		free(tmp);
+	}
 
-    // target is a directory, put file under this target
-    if (is_directory(dstpath)) {
-        const char *basen = path_get_basename(argv[0]);
-        size_t len = strlen(dstpath) + 1 + strlen(basen) + 1;
-        char *newdst = (char *) malloc(len);
-        snprintf(newdst, len, "%s/%s", dstpath, basen);
-        get_file(afc, srcpath, newdst);
-        free(srcpath);
-        free(newdst);
-        free(dstpath);
-    } else {
-        // target is not a dir or does not exist, just try to create or rewrite it
-        get_file(afc, srcpath, dstpath);
-        free(srcpath);
-        free(dstpath);
-    }
+	// target is a directory, put file under this target
+	if (is_directory(dstpath))
+	{
+		const char *basen = path_get_basename(argv[0]);
+		size_t len = strlen(dstpath) + 1 + strlen(basen) + 1;
+		char *newdst = (char *)malloc(len);
+		snprintf(newdst, len, "%s/%s", dstpath, basen);
+		get_file(afc, srcpath, newdst);
+		free(srcpath);
+		free(newdst);
+		free(dstpath);
+	}
+	else
+	{
+		// target is not a dir or does not exist, just try to create or rewrite it
+		get_file(afc, srcpath, dstpath);
+		free(srcpath);
+		free(dstpath);
+	}
 }
 
 static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char *dstpath)
 {
-    FILE *f = fopen(srcpath, "rb");
-    if (!f) {
-        printf("Error: Failed to open local file '%s': %s\n", srcpath, strerror(errno));
-        return 0;
-    }
-    struct timeval t1;
-    struct timeval t2;
-    struct timeval tdiff;
-    struct stat fst;
-    int progress = 0;
-    size_t bufsize = 0x100000;
-    char *buf = malloc(bufsize);
+	FILE *f = fopen(srcpath, "rb");
+	if (!f)
+	{
+		printf("Error: Failed to open local file '%s': %s\n", srcpath, strerror(errno));
+		return 0;
+	}
+	struct timeval t1;
+	struct timeval t2;
+	struct timeval tdiff;
+	struct stat fst;
+	int progress = 0;
+	size_t bufsize = 0x100000;
+	char *buf = malloc(bufsize);
 
-    fstat(fileno(f), &fst);
-    if (fst.st_size >= 0x400000) {
-        progress = 1;
-        gettimeofday(&t1, NULL);
-    }
-    size_t total = 0;
-    int lastprog = 0;
-    uint64_t fh = 0;
-    afc_error_t err = afc_file_open(afc, dstpath, AFC_FOPEN_RW, &fh);
-    uint8_t succeed = 1;
-    while (err == AFC_E_SUCCESS) {
-        uint32_t bytes_read = fread(buf, 1, bufsize, f);
-        if (bytes_read == 0) {
-            if (!feof(f)) {
-                if (progress) {
-                    printf("\n");
-                }
-                printf("Error: Failed to read from local file\n");
-                succeed = 0;
-            }
-            break;
-        }
-        uint32_t chunk = 0;
-        while (chunk < bytes_read) {
-            uint32_t bytes_written = 0;
-            err = afc_file_write(afc, fh, buf + chunk, bytes_read - chunk, &bytes_written);
-            if (err != AFC_E_SUCCESS) {
-                if (progress) {
-                    printf("\n");
-                }
-                printf("Error: Failed to write to device file\n");
-                succeed = 0;
-                break;
-            }
-            chunk += bytes_written;
-        }
-        total += chunk;
-        if (progress) {
-            int prog = (int) ((double) total / (double) fst.st_size * 100.0f);
-            if (prog > lastprog) {
-                gettimeofday(&t2, NULL);
-                timeval_subtract(&tdiff, &t2, &t1);
-                double time_in_sec = (double) tdiff.tv_sec + (double) tdiff.tv_usec / 1000000;
-                printf("\r%d%% (%0.1f MB/s)   ", prog, (double) total / 1048576.0f / time_in_sec);
-                fflush(stdout);
-                lastprog = prog;
-            }
-        }
-    }
-    printf("\n");
-    free(buf);
-    afc_file_close(afc, fh);
-    fclose(f);
-    return succeed;
+	fstat(fileno(f), &fst);
+	if (fst.st_size >= 0x400000)
+	{
+		progress = 1;
+		gettimeofday(&t1, NULL);
+	}
+	size_t total = 0;
+	int lastprog = 0;
+	uint64_t fh = 0;
+	afc_error_t err = afc_file_open(afc, dstpath, AFC_FOPEN_RW, &fh);
+	uint8_t succeed = 1;
+	while (err == AFC_E_SUCCESS)
+	{
+		uint32_t bytes_read = fread(buf, 1, bufsize, f);
+		if (bytes_read == 0)
+		{
+			if (!feof(f))
+			{
+				if (progress)
+				{
+					printf("\n");
+				}
+				printf("Error: Failed to read from local file\n");
+				succeed = 0;
+			}
+			break;
+		}
+		uint32_t chunk = 0;
+		while (chunk < bytes_read)
+		{
+			uint32_t bytes_written = 0;
+			err = afc_file_write(afc, fh, buf + chunk, bytes_read - chunk, &bytes_written);
+			if (err != AFC_E_SUCCESS)
+			{
+				if (progress)
+				{
+					printf("\n");
+				}
+				printf("Error: Failed to write to device file\n");
+				succeed = 0;
+				break;
+			}
+			chunk += bytes_written;
+		}
+		total += chunk;
+		if (progress)
+		{
+			int prog = (int)((double)total / (double)fst.st_size * 100.0f);
+			if (prog > lastprog)
+			{
+				gettimeofday(&t2, NULL);
+				timeval_subtract(&tdiff, &t2, &t1);
+				double time_in_sec = (double)tdiff.tv_sec + (double)tdiff.tv_usec / 1000000;
+				printf("\r%d%% (%0.1f MB/s)   ", prog, (double)total / 1048576.0f / time_in_sec);
+				fflush(stdout);
+				lastprog = prog;
+			}
+		}
+	}
+	printf("\n");
+	free(buf);
+	afc_file_close(afc, fh);
+	fclose(f);
+	return succeed;
 }
 
 static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpath)
 {
-    if (is_directory(srcpath)) {
-        char **info = NULL;
-        afc_error_t err = afc_get_file_info(afc, dstpath, &info);
-        //create if target directory does not exist
-        if (err == AFC_E_OBJECT_NOT_FOUND) {
-            err = afc_make_directory(afc, dstpath);
-            if (err != AFC_E_SUCCESS) {
-                printf("Error: Failed to create directory '%s': %s (%d)\n", dstpath, afc_strerror(err), err);
-                return 0;
-            }
-        }
-        afc_dictionary_free(info);
-        afc_get_file_info(afc, dstpath, &info);
-        uint8_t is_dir = 0;
-        if (info) {
-            char **p = info;
-            while (p && *p) {
-                if (!strcmp(*p, "st_ifmt")) {
-                    p++;
-                    is_dir = !strcmp(*p, "S_IFDIR");
-                    break;
-                }
-                p++;
-            }
-            afc_dictionary_free(info);
-        }
-        if (!is_dir) {
-            printf("Error: Failed to create or access directory: '%s'", dstpath);
-            return 0;
-        }
+	if (is_directory(srcpath))
+	{
+		char **info = NULL;
+		afc_error_t err = afc_get_file_info(afc, dstpath, &info);
+		// create if target directory does not exist
+		if (err == AFC_E_OBJECT_NOT_FOUND)
+		{
+			err = afc_make_directory(afc, dstpath);
+			if (err != AFC_E_SUCCESS)
+			{
+				printf("Error: Failed to create directory '%s': %s (%d)\n", dstpath, afc_strerror(err), err);
+				return 0;
+			}
+		}
+		afc_dictionary_free(info);
+		afc_get_file_info(afc, dstpath, &info);
+		uint8_t is_dir = 0;
+		if (info)
+		{
+			char **p = info;
+			while (p && *p)
+			{
+				if (!strcmp(*p, "st_ifmt"))
+				{
+					p++;
+					is_dir = !strcmp(*p, "S_IFDIR");
+					break;
+				}
+				p++;
+			}
+			afc_dictionary_free(info);
+		}
+		if (!is_dir)
+		{
+			printf("Error: Failed to create or access directory: '%s'", dstpath);
+			return 0;
+		}
 
-        // walk dir recursively to put files
-        DIR *cur_dir = opendir(srcpath);
-        if (cur_dir) {
-            struct dirent *ep;
-            while ((ep = readdir(cur_dir))) {
-                if ((strcmp(ep->d_name, ".") == 0) || (strcmp(ep->d_name, "..") == 0)) {
-                    continue;
-                }
-                char *fpath = string_build_path(srcpath, ep->d_name, NULL);
-                if (fpath) {
-                    size_t len = strlen(srcpath) + 1 + strlen(ep->d_name) + 1;
-                    char *newdst = (char *) malloc(len);
-                    snprintf(newdst, len, "%s/%s", dstpath, ep->d_name);
-                    if (!put_file(afc, fpath, newdst)) {
-                        free(newdst);
-                        free(fpath);
-                        return 0;
-                    }
-                    free(newdst);
-                    free(fpath);
-                }
-            }
-            closedir(cur_dir);
-        } else {
-            printf("Error: Failed to visit directory: '%s': %s", srcpath, strerror(errno));
-            return 0;
-        }
-    } else {
-        return put_single_file(afc, srcpath, dstpath);
-    }
-    return 1;
+		// walk dir recursively to put files
+		DIR *cur_dir = opendir(srcpath);
+		if (cur_dir)
+		{
+			struct dirent *ep;
+			while ((ep = readdir(cur_dir)))
+			{
+				if ((strcmp(ep->d_name, ".") == 0) || (strcmp(ep->d_name, "..") == 0))
+				{
+					continue;
+				}
+				char *fpath = string_build_path(srcpath, ep->d_name, NULL);
+				if (fpath)
+				{
+					size_t len = strlen(srcpath) + 1 + strlen(ep->d_name) + 1;
+					char *newdst = (char *)malloc(len);
+					snprintf(newdst, len, "%s/%s", dstpath, ep->d_name);
+					if (!put_file(afc, fpath, newdst))
+					{
+						free(newdst);
+						free(fpath);
+						return 0;
+					}
+					free(newdst);
+					free(fpath);
+				}
+			}
+			closedir(cur_dir);
+		}
+		else
+		{
+			printf("Error: Failed to visit directory: '%s': %s", srcpath, strerror(errno));
+			return 0;
+		}
+	}
+	else
+	{
+		return put_single_file(afc, srcpath, dstpath);
+	}
+	return 1;
 }
 
 static void handle_put(afc_client_t afc, int argc, char **argv)
 {
-    if (argc < 1 || argc > 2) {
-        printf("Error: Invalid number of arguments\n");
-        return;
-    }
+	if (argc < 1 || argc > 2)
+	{
+		printf("Error: Invalid number of arguments\n");
+		return;
+	}
 
-    char *srcpath = strdup(argv[0]);
-    size_t src_len = strlen(srcpath);
-    if (src_len > 1 && srcpath[src_len - 1] == '/') {
-        srcpath[src_len - 1] = '\0';
-    }
-    char *dstpath = NULL;
-    if (argc == 1) {
-        dstpath = get_absolute_path(path_get_basename(srcpath));
-    } else {
-        char *tmp = strdup(argv[1]);
-        size_t dst_len = strlen(tmp);
-        if (dst_len > 1 && tmp[dst_len - 1] == '/') {
-            tmp[dst_len - 1] = '\0';
-        }
-        dstpath = get_absolute_path(tmp);
-        free(tmp);
-    }
-    char **info = NULL;
-    afc_error_t err = afc_get_file_info(afc, dstpath, &info);
-    // target does not exist, put directly
-    if (err == AFC_E_OBJECT_NOT_FOUND) {
-        put_file(afc, srcpath, dstpath);
-        free(srcpath);
-        free(dstpath);
-    } else {
-        uint8_t is_dir = 0;
-        if (info) {
-            char **p = info;
-            while (p && *p) {
-                if (!strcmp(*p, "st_ifmt")) {
-                    p++;
-                    is_dir = !strcmp(*p, "S_IFDIR");
-                    break;
-                }
-                p++;
-            }
-            afc_dictionary_free(info);
-        }
-        // target is a dir, put under this target
-        if (is_dir) {
-            const char *basen = path_get_basename(srcpath);
-            size_t len = strlen(dstpath) + 1 + strlen(basen) + 1;
-            char *newdst = (char *) malloc(len);
-            snprintf(newdst, len, "%s/%s", dstpath, basen);
-            free(dstpath);
-            dstpath = get_absolute_path(newdst);
-            free(newdst);
-            put_file(afc, srcpath, dstpath);
-        } else {
-            //target is common file, rewrite it
-            put_file(afc, srcpath, dstpath);
-        }
-        free(srcpath);
-        free(dstpath);
-    }
+	char *srcpath = strdup(argv[0]);
+	size_t src_len = strlen(srcpath);
+	if (src_len > 1 && srcpath[src_len - 1] == '/')
+	{
+		srcpath[src_len - 1] = '\0';
+	}
+	char *dstpath = NULL;
+	if (argc == 1)
+	{
+		dstpath = get_absolute_path(path_get_basename(srcpath));
+	}
+	else
+	{
+		char *tmp = strdup(argv[1]);
+		size_t dst_len = strlen(tmp);
+		if (dst_len > 1 && tmp[dst_len - 1] == '/')
+		{
+			tmp[dst_len - 1] = '\0';
+		}
+		dstpath = get_absolute_path(tmp);
+		free(tmp);
+	}
+	char **info = NULL;
+	afc_error_t err = afc_get_file_info(afc, dstpath, &info);
+	// target does not exist, put directly
+	if (err == AFC_E_OBJECT_NOT_FOUND)
+	{
+		put_file(afc, srcpath, dstpath);
+		free(srcpath);
+		free(dstpath);
+	}
+	else
+	{
+		uint8_t is_dir = 0;
+		if (info)
+		{
+			char **p = info;
+			while (p && *p)
+			{
+				if (!strcmp(*p, "st_ifmt"))
+				{
+					p++;
+					is_dir = !strcmp(*p, "S_IFDIR");
+					break;
+				}
+				p++;
+			}
+			afc_dictionary_free(info);
+		}
+		// target is a dir, put under this target
+		if (is_dir)
+		{
+			const char *basen = path_get_basename(srcpath);
+			size_t len = strlen(dstpath) + 1 + strlen(basen) + 1;
+			char *newdst = (char *)malloc(len);
+			snprintf(newdst, len, "%s/%s", dstpath, basen);
+			free(dstpath);
+			dstpath = get_absolute_path(newdst);
+			free(newdst);
+			put_file(afc, srcpath, dstpath);
+		}
+		else
+		{
+			// target is common file, rewrite it
+			put_file(afc, srcpath, dstpath);
+		}
+		free(srcpath);
+		free(dstpath);
+	}
 }
 
 static void handle_pwd(afc_client_t afc, int argc, char** argv)


### PR DESCRIPTION
The original implementation of `get` and `put` of `afcclient` supports only single file. This PR make it work for directories. 