### PR TITLE
afcclient: add missing time.h header

### DIFF
--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <time.h>
 
 #ifdef WIN32
 #include <windows.h>


### PR DESCRIPTION
Needed for strftime and localtime.