### PR TITLE
Fix implicit fallthrough in lockdown.c

### DIFF
--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -846,6 +846,7 @@ static lockdownd_error_t pair_record_generate(lockdownd_client_t client, plist_t
 			break;
 		case USERPREF_E_SSL_ERROR:
 			ret = LOCKDOWN_E_SSL_ERROR;
+			break;
 		default:
 			break;
 	}


### PR DESCRIPTION
Allows `-Wimplicit-fallthrough` to pass in LLVM.