### PR TITLE
Add android exception for pthread detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,9 @@ case ${host_os} in
     AC_MSG_RESULT([${host_os}])
     darwin=true
     ;;
+  *android*)
+    AC_MSG_RESULT([${host_os}])
+    ;;
   *)
     AC_MSG_RESULT([${host_os}])
     AX_PTHREAD([], [AC_MSG_ERROR([pthread is required to build $PACKAGE_NAME])])


### PR DESCRIPTION
I have an issue similar to https://github.com/libimobiledevice/libplist/issues/82 in libimobiledevice. For the same reason, I believe that the pthread detection can be ignored for Android.

This patch fixes my cross-compilation for android-arm64 :+1:.