### PR TITLE
idevice.c stack corruption

### DIFF
--- a/src/idevice.c
+++ b/src/idevice.c
@@ -1075,7 +1075,8 @@ static long ssl_idevice_bio_callback(BIO *b, int oper, const char *argp, int arg
 	idevice_connection_t conn = (idevice_connection_t)BIO_get_callback_arg(b);
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 	size_t len = (size_t)argi;
-	size_t *processed = (size_t*)&bytes;
+	long tempbytes = 0;
+	size_t *processed = (size_t*)&tempbytes;
 #endif
 	switch (oper) {
 	case (BIO_CB_READ|BIO_CB_RETURN):


### PR DESCRIPTION
when building on windows for 64bit with openssl version < 3.0 assignment on lines 1084 and 1093 in original code causes stack corruption. this is safe approach, since *processed is not used anyways, but we need value of bytes

stack corruption didn't happen in 32bit build, but i assume, it might also happen, since original construct is really bad.