### PR TITLE
Add unmatch filter option to idevicesyslog.

### DIFF
--- a/docs/idevicesyslog.1
+++ b/docs/idevicesyslog.1
@@ -44,6 +44,11 @@ Force writing colored output, e.g. when using \f[B]\-\-output\f[].
 .B \-m, \-\-match STRING
 only print messages that contain STRING
 
+.SH FILTER OPTIONS
+.TP
+.B \-M, \-\-unmatch STRING
+print messages that not contain STRING
+
 This option will set a filter to only printed log messages that contain the given string.
 .TP
 .B \-t, \-\-trigger STRING


### PR DESCRIPTION
The new -M/--unmatch option allows filtering out messages containing specific strings, complementing the existing -m/--match functionality. This provides more flexible log filtering capabilities for users.