### PR TITLE
afcclient: Correct ctype(3) usage

### DIFF
--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -1487,7 +1487,7 @@ static void str_remove_spaces(char *source)
 {
 	char *dest = source;
 	while (*source != 0) {
-		if (!isspace(*source)) {
+		if (!isspace((unsigned char)*source)) {
 			*dest++ = *source; /* copy */
 		}
 		source++;

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -1235,7 +1235,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 	int is_error = 0;
 
 	/* skip initial whitespace */
-	while (isspace(*pos)) pos++;
+	while (isspace((unsigned char)*pos)) pos++;
 	maxlen -= (pos - cmdline);
 
 	tmpbuf = (char*)malloc(maxlen+1);
@@ -1263,7 +1263,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 				qpos = NULL;
 			}
 			pos++;
-		} else if (*pos == '\0' || (!qpos && isspace(*pos))) {
+		} else if (*pos == '\0' || (!qpos && isspace((unsigned char)*pos))) {
 			tmpbuf[tmplen] = '\0';
 			if (*pos == '\0' && qpos) {
 				printf("Error: Unmatched `%c`\n", *qpos);
@@ -1292,7 +1292,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 			maxlen -= tmplen;
 			tmpbuf = (char*)malloc(maxlen+1);
 			tmplen = 0;
-			while (isspace(*pos)) pos++;
+			while (isspace((unsigned char)*pos)) pos++;
 		} else {
 			tmpbuf[tmplen++] = *pos;
 			pos++;


### PR DESCRIPTION
According to POSIX.1 the argument of ctype(3) functions, including isspace(3), has to either be EOF or a value representable as an unsigned char. If the argument has any other value, the behavior is undefined. This means values of signed char must first be cast to unsigned char, otherwise they will be outside the range of allowed values.

glibc attempts to avoid the undefined behavior by defining the functions to work for all integer inputs representable by either an unsigned char or a signed char. NetBSD libc does not, and causes a segfault if the value is invalid.