### PR TITLE
Changes to make afcclient more useful

### DIFF
--- a/docs/afcclient.1
+++ b/docs/afcclient.1
@@ -36,10 +36,10 @@ Create a (symbolic) link to file named LINKNAME. \f[B]NOTE: This feature has bee
 remove item at PATH
 .TP
 .B get [-rf] [-p] PATH [LOCALPATH]
-transfer file at PATH from device to LOCALPATH, or current directory if omitted. If LOCALPATH is a directory, the file will be stored inside the directory. If \-p is specified, preserve modification times.
+transfer file at PATH from device to LOCALPATH, or current directory if omitted. If LOCALPATH is a directory, the file will be stored inside the directory. If \fB\-p\fP is specified, preserve modification times.
 .TP
-.B put [-rf] LOCALPATH [PATH]
-transfer local file at LOCALPATH to device at PATH, or current directory if omitted. If PATH is a directory, the file will be stored inside the directory.
+.B put [-rf] [-p] LOCALPATH [PATH]
+transfer local file at LOCALPATH to device at PATH, or current directory if omitted. If PATH is a directory, the file will be stored inside the directory. If \fB\-p\fP is specified, preserve modification times.
 .TP
 
 .SH OPTIONS

--- a/docs/afcclient.1
+++ b/docs/afcclient.1
@@ -35,8 +35,8 @@ Create a (symbolic) link to file named LINKNAME. \f[B]NOTE: This feature has bee
 .B rm [-rf] PATH
 remove item at PATH
 .TP
-.B get [-rf] PATH [LOCALPATH]
-transfer file at PATH from device to LOCALPATH, or current directory if omitted. If LOCALPATH is a directory, the file will be stored inside the directory.
+.B get [-rf] [-p] PATH [LOCALPATH]
+transfer file at PATH from device to LOCALPATH, or current directory if omitted. If LOCALPATH is a directory, the file will be stored inside the directory. If \-p is specified, preserve modification times.
 .TP
 .B put [-rf] LOCALPATH [PATH]
 transfer local file at LOCALPATH to device at PATH, or current directory if omitted. If PATH is a directory, the file will be stored inside the directory.

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -1493,7 +1493,7 @@ static int process_args(afc_client_t afc, int argc, char** argv)
 	return 0;
 }
 
-char *_get_input(const char *prompt)
+static char *_get_input(const char *prompt)
 {
 #ifdef HAVE_READLINE
 	if (interactive) {

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -234,7 +234,7 @@ static void handle_help(afc_client_t afc, int argc, char** argv)
 	printf("ln [-s] FILE [LINK] - create a (symbolic) link to file named LINKNAME\n");
 	printf("        NOTE: This feature has been disabled in newer versions of iOS.\n");
 	printf("rm PATH - remove item at PATH\n");
-	printf("get [-rf] PATH [LOCALPATH] - transfer file at PATH from device to LOCALPATH\n");
+	printf("get [-rf] [-p] PATH [LOCALPATH] - transfer file at PATH from device to LOCALPATH\n");
 	printf("put [-rf] LOCALPATH [PATH] - transfer local file at LOCALPATH to device at PATH\n");
 	printf("\n");
 }

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -731,7 +731,8 @@ static void handle_remove(afc_client_t afc, int argc, char** argv)
 	for ( ; i < argc; i++) {
 		char* abspath = get_absolute_path(argv[i]);
 		if (!abspath) {
-			printf("Error: Invalid argument '%s'\n", argv[i]);
+			fprintf(stderr, "%s: Invalid argument '%s'\n", myname, argv[i]);
+			errors++;
 			continue;
 		}
 		afc_error_t err;
@@ -741,7 +742,8 @@ static void handle_remove(afc_client_t afc, int argc, char** argv)
 			err = afc_remove_path(afc, abspath);
 		}
 		if (err != AFC_E_SUCCESS) {
-			printf("Error: Failed to remove '%s': %s (%d)\n", argv[i], afc_strerror(err), err);
+			fprintf(stderr, "%s: Failed to remove '%s': %s (%d)\n", myname, argv[i], afc_strerror(err), err);
+			errors++;
 		}
 		free(abspath);
 	}
@@ -752,16 +754,19 @@ static uint8_t get_single_file(afc_client_t afc, const char *srcpath, const char
 	uint64_t fh = 0;
 	afc_error_t err = afc_file_open(afc, srcpath, AFC_FOPEN_RDONLY, &fh);
 	if (err != AFC_E_SUCCESS) {
-		printf("Error: Failed to open file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to open file '%s': %s (%d)\n", myname, srcpath, afc_strerror(err), err);
+		errors++;
 		return 0;
 	}
 	if (file_exists(dstpath) && !force_overwrite) {
-		printf("Error: Failed to overwrite existing file without '-f' option: %s\n", dstpath);
+		fprintf(stderr, "%s: Failed to overwrite existing file without '-f' option: %s\n", myname, dstpath);
+		errors++;
 		return 0;
 	}
 	FILE *f = fopen(dstpath, "wb");
 	if (!f) {
-		printf("Error: Failed to open local file '%s': %s\n", dstpath, strerror(errno));
+		fprintf(stderr, "%s: Failed to open local file '%s': %s\n", myname, dstpath, strerror(errno));
+		errors++;
 		return 0;
 	}
 	struct timeval t1;
@@ -790,7 +795,7 @@ static uint8_t get_single_file(afc_client_t afc, const char *srcpath, const char
 				if (progress) {
 					printf("\n");
 				}
-				printf("Error: Failed to write to local file\n");
+				fprintf(stderr, "%s: Failed to write to local file\n", myname);
 				succeed = 0;
 				break;
 			}
@@ -813,7 +818,8 @@ static uint8_t get_single_file(afc_client_t afc, const char *srcpath, const char
 		printf("\n");
 	}
 	if (err != AFC_E_SUCCESS) {
-		printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to read from file '%s': %s (%d)\n", myname, srcpath, afc_strerror(err), err);
+		errors++;
 		succeed = 0;
 	}
 	free(buf);
@@ -855,7 +861,8 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 	uint64_t file_size = 0, file_mtime = 0;
 	afc_error_t err = afc_get_file_info_plist(afc, srcpath, &info);
 	if (err == AFC_E_OBJECT_NOT_FOUND) {
-		printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to read from file '%s': %s (%d)\n", myname, srcpath, afc_strerror(err), err);
+		errors++;
 		return 0;
 	}
 	uint8_t is_dir = 0;
@@ -869,13 +876,15 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 	uint8_t succeed = 1;
 	if (is_dir) {
 		if (!recursive_get) {
-			printf("Error: Failed to get a directory without '-r' option: %s\n", srcpath);
+			fprintf(stderr, "%s: Failed to get a directory without '-r' option: %s\n", myname, srcpath);
+			errors++;
 			return 0;
 		}
 		char **entries = NULL;
 		err = afc_read_directory(afc, srcpath, &entries);
 		if (err != AFC_E_SUCCESS) {
-			printf("Error: Failed to list '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
+			fprintf(stderr, "%s: Failed to list '%s': %s (%d)\n", myname, srcpath, afc_strerror(err), err);
+			errors++;
 			return 0;
 		}
 		char **p = entries;
@@ -884,11 +893,13 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 		// if directory exists, check force_overwrite flag
 		if (is_directory(dstpath)) {
 			if (!force_overwrite) {
-				printf("Error: Failed to write into existing directory without '-f': %s\n", dstpath);
+				fprintf(stderr, "%s: Failed to write into existing directory without '-f': %s\n", myname, dstpath);
+				errors++;
 				return 0;
 			}
 		} else if (__mkdir(dstpath) != 0) {
-			printf("Error: Failed to create directory '%s': %s\n", dstpath, strerror(errno));
+			fprintf(stderr, "%s: Failed to create directory '%s': %s\n", myname, dstpath, strerror(errno));
+			errors++;
 			afc_dictionary_free(entries);
 			return 0;
 		}
@@ -933,7 +944,8 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 static void handle_get(afc_client_t afc, int argc, char **argv)
 {
 	if (argc < 1) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	uint8_t force_overwrite = 0, recursive_get = 0, preserve = 0;
@@ -980,7 +992,8 @@ static void handle_get(afc_client_t afc, int argc, char **argv)
 		}
 		free(tmp);
 	} else {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 
@@ -1015,13 +1028,15 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 	if (ret == AFC_E_SUCCESS && info) {
 		plist_free(info);
 		if (!force_overwrite) {
-			printf("Error: Failed to write into existing file without '-f' option: %s\n", dstpath);
+			fprintf(stderr, "%s: Failed to write into existing file without '-f' option: %s\n", myname, dstpath);
+			errors++;
 			return 0;
 		}
 	}
 	FILE *f = fopen(srcpath, "rb");
 	if (!f) {
-		printf("Error: Failed to open local file '%s': %s\n", srcpath, strerror(errno));
+		fprintf(stderr, "%s: Failed to open local file '%s': %s\n", myname, srcpath, strerror(errno));
+		errors++;
 		return 0;
 	}
 	struct timeval t1;
@@ -1049,7 +1064,8 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 				if (progress) {
 					printf("\n");
 				}
-				printf("Error: Failed to read from local file\n");
+				fprintf(stderr, "%s: Failed to read from local file\n", myname);
+				errors++;
 				succeed = 0;
 			}
 			break;
@@ -1062,7 +1078,8 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 				if (progress) {
 					printf("\n");
 				}
-				printf("Error: Failed to write to device file\n");
+				fprintf(stderr, "%s: Failed to write to device file\n", myname);
+				errors++;
 				succeed = 0;
 				break;
 			}
@@ -1094,7 +1111,8 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 {
 	if (is_directory(srcpath)) {
 		if (!recursive_put) {
-			printf("Error: Failed to put directory without '-r' option: %s\n", srcpath);
+			fprintf(stderr, "%s: Failed to put directory without '-r' option: %s\n", myname, srcpath);
+			errors++;
 			return 0;
 		}
 		plist_t info = NULL;
@@ -1105,11 +1123,13 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 		if (err == AFC_E_OBJECT_NOT_FOUND) {
 			err = afc_make_directory(afc, dstpath);
 			if (err != AFC_E_SUCCESS) {
-				printf("Error: Failed to create directory '%s': %s (%d)\n", dstpath, afc_strerror(err), err);
+				fprintf(stderr, "%s: Failed to create directory '%s': %s (%d)\n", myname, dstpath, afc_strerror(err), err);
+				errors++;
 				return 0;
 			}
 		} else if (!force_overwrite) {
-			printf("Error: Failed to put existing directory without '-f' option: %s\n", dstpath);
+			fprintf(stderr, "%s: Failed to put existing directory without '-f' option: %s\n", myname, dstpath);
+			errors++;
 			return 0;
 		}
 		afc_get_file_info_plist(afc, dstpath, &info);
@@ -1120,7 +1140,8 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 			plist_free(info);
 		}
 		if (!is_dir) {
-			printf("Error: Failed to create or access directory: '%s'\n", dstpath);
+			fprintf(stderr, "%s: Failed to create or access directory: '%s'\n", myname, dstpath);
+			errors++;
 			return 0;
 		}
 
@@ -1153,7 +1174,8 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 			}
 			closedir(cur_dir);
 		} else {
-			printf("Error: Failed to visit directory: '%s': %s\n", srcpath, strerror(errno));
+			fprintf(stderr, "%s: Failed to visit directory: '%s': %s\n", myname, srcpath, strerror(errno));
+			errors++;
 			return 0;
 		}
 	} else {
@@ -1165,7 +1187,8 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 static void handle_put(afc_client_t afc, int argc, char **argv)
 {
 	if (argc < 1) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	int i = 0;
@@ -1186,7 +1209,8 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 		}
 	}
 	if (i >= argc) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	char *srcpath = mstrdup(argv[i]);
@@ -1206,7 +1230,8 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 		dstpath = get_absolute_path(tmp);
 		free(tmp);
 	} else {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	plist_t info = NULL;
@@ -1255,7 +1280,8 @@ static void handle_pwd(afc_client_t afc, int argc, char** argv)
 static void handle_cd(afc_client_t afc, int argc, char** argv)
 {
 	if (argc != 1) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 
@@ -1289,13 +1315,15 @@ static void handle_cd(afc_client_t afc, int argc, char** argv)
 		is_dir = (ifmt && !strcmp(ifmt, "S_IFDIR"));
 		plist_free(info);
 	} else {
-		printf("Error: Failed to get file info for %s: %s (%d)\n", path, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to get file info for %s: %s (%d)\n", myname, path, afc_strerror(err), err);
+		errors++;
 		free(path);
 		return;
 	}
 
 	if (!is_dir) {
-		printf("Error: '%s' is not a valid directory\n", path);
+		fprintf(stderr, "%s: '%s' is not a valid directory\n", myname, path);
+		errors++;
 		free(path);
 		return;
 	}
@@ -1334,7 +1362,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 					pos++;
 					break;
 				default:
-					printf("Error: Invalid escape sequence\n");
+					fprintf(stderr, "%s: Invalid escape sequence\n", myname);
 					is_error++;
 					break;
 			}
@@ -1348,13 +1376,13 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 		} else if (*pos == '\0' || (!qpos && isspace(*pos))) {
 			tmpbuf[tmplen] = '\0';
 			if (*pos == '\0' && qpos) {
-				printf("Error: Unmatched `%c`\n", *qpos);
+				fprintf(stderr, "%s: Unmatched `%c`\n", myname, *qpos);
 				is_error++;
 				break;
 			}
 			char** new_argv = (char**)realloc(argv, (argc+1)*sizeof(char*));
 			if (new_argv == NULL) {
-				printf("Error: Out of memory?!\n");
+				fprintf(stderr, "%s: Out of memory?!\n", myname);
 				is_error++;
 				break;
 			}
@@ -1362,7 +1390,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 			/* shrink buffer to actual argument size */
 			argv[argc] = (char*)realloc(tmpbuf, tmplen+1);
 			if (!argv[argc]) {
-				printf("Error: Out of memory?!\n");
+				fprintf(stderr, "%s: Out of memory?!\n", myname);
 				is_error++;
 				break;
 			}
@@ -1436,7 +1464,7 @@ static int process_args(afc_client_t afc, int argc, char** argv)
 		handle_cd(afc, argc-1, argv+1);
 	}
 	else {
-		printf("Unknown command '%s'. Type 'help' to get a list of available commands.\n", argv[0]);
+		fprintf(stderr, "%s: Unknown command '%s'. Type 'help' to get a list of available commands.\n", myname, argv[0]);
 	}
 	return 0;
 }
@@ -1536,9 +1564,13 @@ int main(int argc, char** argv)
 	signal(SIGPIPE, SIG_IGN);
 #endif
 
+#ifdef _WIN32
+	myname = "afcclient";
+#else
 	char *scratch1 = mstrdup(argv[0]);
 	myname = mstrdup(basename(scratch1));
 	free(scratch1);
+#endif
 
 	while ((c = getopt_long(argc, argv, "du:nhv", longopts, NULL)) != -1) {
 		switch (c) {

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -27,6 +27,7 @@
 #endif
 
 #define TOOL_NAME "afcclient"
+#define NANO 1000000000
 
 #include <stdio.h>
 #include <string.h>
@@ -38,11 +39,14 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <time.h>
+#include <libgen.h>
 #include <sys/stat.h>
 
 #ifdef _WIN32
 #include <windows.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/utime.h>
 #include <conio.h>
 #define sleep(x) Sleep(x*1000)
 #define S_IFMT          0170000         /* [XSI] type of file mask */
@@ -57,6 +61,7 @@
 #define S_ISLNK(m)      (((m) & S_IFMT) == S_IFLNK)     /* symbolic link */
 #define S_ISSOCK(m)     (((m) & S_IFMT) == S_IFSOCK)    /* socket */
 #else
+#include <fcntl.h>
 #include <sys/time.h>
 #include <termios.h>
 #endif
@@ -92,6 +97,33 @@ static int use_network = 0;
 static idevice_subscription_context_t context = NULL;
 static char* curdir = NULL;
 static size_t curdir_len = 0;
+static char* myname = NULL;
+static int errors = 0;
+
+static void mabort()
+{
+	const char *message = "out of memory!\n";
+	write(2, message, strlen(message));
+	abort();
+}
+
+static void *mmalloc(size_t size)
+{
+	void *ret = malloc(size);
+	if (ret == NULL) {
+		mabort();
+	}
+	return ret;
+}
+
+static char *mstrdup(const char *s)
+{
+	char *ret = strdup(s);
+	if (ret == NULL) {
+		mabort();
+	}
+	return ret;
+}
 
 static int file_exists(const char* path)
 {
@@ -242,10 +274,10 @@ struct str_item {
 static char* get_absolute_path(const char *path)
 {
 	if (*path == '/') {
-		return strdup(path);
+		return mstrdup(path);
 	} else {
 		size_t len = curdir_len + 1 + strlen(path) + 1;
-		char* result = (char*)malloc(len);
+		char* result = (char*)mmalloc(len);
 		if (!strcmp(curdir, "/")) {
 			snprintf(result, len, "/%s", path);
 		} else {
@@ -269,7 +301,7 @@ static char* get_realpath(const char* path)
 		while (*p == '/') p++;
 	}
 	if (*p == '\0') {
-		return strdup("/");
+		return mstrdup("/");
 	}
 
 	int c_count = 1;
@@ -290,7 +322,7 @@ static char* get_realpath(const char* path)
 				return NULL;
 			}
 			comps = newcomps;
-			char *comp = (char*)malloc(end-start+1);
+			char *comp = (char*)mmalloc(end-start+1);
 			strncpy(comp, start, end-start);
 			comp[end-start] = '\0';
 			comps[c_count-1].len = end-start;
@@ -312,14 +344,14 @@ static char* get_realpath(const char* path)
 			return NULL;
 		}
 		comps = newcomps;
-		char *comp = (char*)malloc(end-start+1);
+		char *comp = (char*)mmalloc(end-start+1);
 		strncpy(comp, start, end-start);
 		comp[end-start] = '\0';
 		comps[c_count-1].len = end-start;
 		comps[c_count-1].str = comp;
 	}
 
-	struct str_item* comps_final = (struct str_item*)malloc(sizeof(struct str_item)*(c_count+1));
+	struct str_item* comps_final = (struct str_item*)mmalloc(sizeof(struct str_item)*(c_count+1));
 	int o = 1;
 	if (is_absolute) {
 		comps_final[0].len = 1;
@@ -344,7 +376,7 @@ static char* get_realpath(const char* path)
 	}
 
 	o_len += o;
-	char* result = (char*)malloc(o_len);
+	char* result = (char*)mmalloc(o_len);
 	char* presult = result;
 	for (int i = 0; i < o; i++) {
 		if (i > 0 && strcmp(comps_final[i-1].str, "/") != 0) {
@@ -381,7 +413,8 @@ static void handle_devinfo(afc_client_t afc, int argc, char** argv)
 			plist_write_to_stream(info, stdout, PLIST_FORMAT_JSON, PLIST_OPT_NONE);
 		}
 	} else {
-		printf("Error: Failed to get device info: %s (%d)\n", afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to get device info: %s (%d)\n", myname, afc_strerror(err), err);
+		errors++;
 	}
 	plist_free(info);
 }
@@ -417,9 +450,9 @@ static int get_file_info_stat(afc_client_t afc, const char* path, struct afc_fil
 		}
 	}
 	stbuf->st_nlink = plist_dict_get_uint(info, "st_nlink");
-	stbuf->st_mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / 1000000000);
+	stbuf->st_mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / NANO);
 	/* available on iOS 7+ */
-	stbuf->st_birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / 1000000000);
+	stbuf->st_birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / NANO);
 	plist_free(info);
 	return 0;
 }
@@ -427,14 +460,16 @@ static int get_file_info_stat(afc_client_t afc, const char* path, struct afc_fil
 static void handle_file_info(afc_client_t afc, int argc, char** argv)
 {
 	if (argc < 1) {
-		printf("Error: Missing PATH.\n");
+		fprintf(stderr, "%s: Missing PATH.\n", myname);
+		errors++;
 		return;
 	}
 
 	plist_t info = NULL;
 	char* abspath = get_absolute_path(argv[0]);
 	if (!abspath) {
-		printf("Error: Invalid argument\n");
+		fprintf(stderr, "%s: Invalid argument\n", myname);
+		errors++;
 		return;
 	}
 	afc_error_t err = afc_get_file_info_plist(afc, abspath, &info);
@@ -445,7 +480,8 @@ static void handle_file_info(afc_client_t afc, int argc, char** argv)
 			plist_write_to_stream(info, stdout, PLIST_FORMAT_JSON, PLIST_OPT_NONE);
 		}
 	} else {
-		printf("Error: Failed to get file info for %s: %s (%d)\n", argv[0], afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to get file info for %s: %s (%d)\n", myname, argv[0], afc_strerror(err), err);
+		errors++;
 	}
 	plist_free(info);
 	free(abspath);
@@ -525,7 +561,8 @@ static void handle_list(afc_client_t afc, int argc, char** argv)
 	}
 	char* abspath = get_absolute_path(path);
 	if (!abspath) {
-		printf("Error: Invalid argument\n");
+		fprintf(stderr, "%s: Invalid argument\n", myname);
+		errors++;
 		return;
 	}
 	int abspath_is_root = strcmp(abspath, "/") == 0;
@@ -536,7 +573,8 @@ static void handle_list(afc_client_t afc, int argc, char** argv)
 		print_file_info(afc, abspath, list_verbose);
 		return;
 	} else if (err != AFC_E_SUCCESS) {
-		printf("Error: Failed to list '%s': %s (%d)\n", path, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to list '%s': %s (%d)\n", myname, path, afc_strerror(err), err);
+		errors++;
 		free(abspath);
 		return;
 	}
@@ -548,7 +586,7 @@ static void handle_list(afc_client_t afc, int argc, char** argv)
 			continue;
 		}
 		size_t len = abspath_len + 1 + strlen(*p) + 1;
-		char* testpath = (char*)malloc(len);
+		char* testpath = (char*)mmalloc(len);
 		if (abspath_is_root) {
 			snprintf(testpath, len, "/%s", *p);
 		} else {
@@ -565,23 +603,27 @@ static void handle_list(afc_client_t afc, int argc, char** argv)
 static void handle_rename(afc_client_t afc, int argc, char** argv)
 {
 	if (argc != 2) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	char* srcpath = get_absolute_path(argv[0]);
 	if (!srcpath) {
-		printf("Error: Invalid argument\n");
+		fprintf(stderr, "%s: Invalid argument\n", myname);
+		errors++;
 		return;
 	}
 	char* dstpath = get_absolute_path(argv[1]);
 	if (!dstpath) {
 		free(srcpath);
-		printf("Error: Invalid argument\n");
+		fprintf(stderr, "%s: Invalid argument\n", myname);
+		errors++;
 		return;
 	}
 	afc_error_t err = afc_rename_path(afc, srcpath, dstpath);
 	if (err != AFC_E_SUCCESS) {
-		printf("Error: Failed to rename '%s' -> '%s': %s (%d)\n", argv[0], argv[1], afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to rename '%s' -> '%s': %s (%d)\n", myname, argv[0], argv[1], afc_strerror(err), err);
+		errors++;
 	}
 	free(srcpath);
 	free(dstpath);
@@ -592,12 +634,14 @@ static void handle_mkdir(afc_client_t afc, int argc, char** argv)
 	for (int i = 0; i < argc; i++) {
 		char* abspath = get_absolute_path(argv[i]);
 		if (!abspath) {
-			printf("Error: Invalid argument '%s'\n", argv[i]);
+			fprintf(stderr, "%s: Invalid argument '%s'\n", myname, argv[i]);
+			errors++;
 			continue;
 		}
 		afc_error_t err = afc_make_directory(afc, abspath);
 		if (err != AFC_E_SUCCESS) {
-			printf("Error: Failed to create directory '%s': %s (%d)\n", argv[i], afc_strerror(err), err);
+			fprintf(stderr, "%s: Failed to create directory '%s': %s (%d)\n", myname, argv[i], afc_strerror(err), err);
+			errors++;
 		}
 		free(abspath);
 	}
@@ -606,7 +650,8 @@ static void handle_mkdir(afc_client_t afc, int argc, char** argv)
 static void handle_link(afc_client_t afc, int argc, char** argv)
 {
 	if (argc < 2) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	afc_link_type_t link_type = AFC_HARDLINK;
@@ -616,18 +661,21 @@ static void handle_link(afc_client_t afc, int argc, char** argv)
 		link_type = AFC_SYMLINK;
 	}
 	if (argc < 1 || argc > 2) {
-		printf("Error: Invalid number of arguments\n");
+		fprintf(stderr, "%s: Invalid number of arguments\n", myname);
+		errors++;
 		return;
 	}
 	const char *link_name = (argc == 1) ? path_get_basename(argv[0]) : argv[1];
 	char* abs_link_name = get_absolute_path(link_name);
 	if (!abs_link_name) {
-		printf("Error: Invalid argument\n");
+		fprintf(stderr, "%s: Invalid argument\n", myname);
+		errors++;
 		return;
 	}
 	afc_error_t err = afc_make_link(afc, link_type, argv[0], link_name);
 	if (err != AFC_E_SUCCESS) {
-		printf("Error: Failed to create %s link for '%s' at '%s': %s (%d)\n", (link_type == AFC_HARDLINK) ? "hard" : "symbolic", argv[0], link_name, afc_strerror(err), err);
+		fprintf(stderr, "%s: Failed to create %s link for '%s' at '%s': %s (%d)\n", myname, (link_type == AFC_HARDLINK) ? "hard" : "symbolic", argv[0], link_name, afc_strerror(err), err);
+		errors++;
 	}
 }
 
@@ -720,7 +768,7 @@ static uint8_t get_single_file(afc_client_t afc, const char *srcpath, const char
 	struct timeval t2;
 	struct timeval tdiff;
 	size_t bufsize = 0x100000;
-	char *buf = malloc(bufsize);
+	char *buf = mmalloc(bufsize);
 	size_t total = 0;
 	int progress = 0;
 	int lastprog = 0;
@@ -783,10 +831,28 @@ static int __mkdir(const char* path)
 #endif
 }
 
-static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint8_t force_overwrite, uint8_t recursive_get)
+static void set_mtime(const char *path, uint64_t mtime)
+{
+#ifdef _WIN32
+	time_t now;
+	time(&now);
+	struct _utimbuf times;
+	times.actime = now;
+	times.modtime = mtime / NANO;
+	_utime(dstpath, &times);
+#else
+	struct timespec times[2];
+	times[0].tv_nsec = UTIME_OMIT;
+	times[1].tv_sec = mtime / NANO;
+	times[1].tv_nsec = mtime % NANO;
+	utimensat(AT_FDCWD, path, times, 0);
+#endif
+}
+
+static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint8_t force_overwrite, uint8_t recursive_get, uint8_t preserve)
 {
 	plist_t info = NULL;
-	uint64_t file_size = 0;
+	uint64_t file_size = 0, file_mtime = 0;
 	afc_error_t err = afc_get_file_info_plist(afc, srcpath, &info);
 	if (err == AFC_E_OBJECT_NOT_FOUND) {
 		printf("Error: Failed to read from file '%s': %s (%d)\n", srcpath, afc_strerror(err), err);
@@ -795,6 +861,7 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 	uint8_t is_dir = 0;
 	if (info) {
 		file_size = plist_dict_get_uint(info, "st_size");
+		file_mtime = plist_dict_get_uint(info, "st_mtime");
 		const char* ifmt = plist_get_string_ptr(plist_dict_get_item(info, "st_ifmt"), NULL);
 		is_dir = (ifmt && !strcmp(ifmt, "S_IFDIR"));
 		plist_free(info);
@@ -831,7 +898,7 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 				continue;
 			}
 			size_t len = srcpath_is_root ? (strlen(*p) + 2) : (srcpath_len + 1 + strlen(*p) + 1);
-			char *testpath = (char *) malloc(len);
+			char *testpath = (char *) mmalloc(len);
 			if (srcpath_is_root) {
 				snprintf(testpath, len, "/%s", *p);
 			} else {
@@ -839,13 +906,13 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 			}
 			uint8_t dst_is_root = strcmp(srcpath, "/") == 0;
 			size_t dst_len = dst_is_root ? (strlen(*p) + 2) : (strlen(dstpath) + 1 + strlen(*p) + 1);
-			char *newdst = (char *) malloc(dst_len);
+			char *newdst = (char *) mmalloc(dst_len);
 			if (dst_is_root) {
 				snprintf(newdst, dst_len, "/%s", *p);
 			} else {
 				snprintf(newdst, dst_len, "%s/%s", dstpath, *p);
 			}
-			if (!get_file(afc, testpath, newdst, force_overwrite, recursive_get)) {
+			if (!get_file(afc, testpath, newdst, force_overwrite, recursive_get, preserve)) {
 				succeed = 0;
 				break;
 			}
@@ -856,6 +923,9 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 		afc_dictionary_free(entries);
 	} else {
 		succeed = get_single_file(afc, srcpath, dstpath, file_size, force_overwrite);
+		if (preserve && file_mtime) {
+			set_mtime(dstpath, file_mtime);
+		}
 	}
 	return succeed;
 }
@@ -866,7 +936,7 @@ static void handle_get(afc_client_t afc, int argc, char **argv)
 		printf("Error: Invalid number of arguments\n");
 		return;
 	}
-	uint8_t force_overwrite = 0, recursive_get = 0;
+	uint8_t force_overwrite = 0, recursive_get = 0, preserve = 0;
 	char *srcpath = NULL;
 	char *dstpath = NULL;
 	int i = 0;
@@ -881,27 +951,29 @@ static void handle_get(afc_client_t afc, int argc, char **argv)
 		} else if (!strcmp(argv[i], "-rf") || !strcmp(argv[i], "-fr")) {
 			recursive_get = 1;
 			force_overwrite = 1;
+		} else if (!strcmp(argv[i], "-p")) {
+			preserve = 1;
 		} else {
 			break;
 		}
 	}
 	if (argc - i == 1) {
-		char *tmp = strdup(argv[i]);
+		char *tmp = mstrdup(argv[i]);
 		size_t src_len = strlen(tmp);
 		if (src_len > 1 && tmp[src_len - 1] == '/') {
 			tmp[src_len - 1] = '\0';
 		}
 		srcpath = get_absolute_path(tmp);
-		dstpath = strdup(path_get_basename(tmp));
+		dstpath = mstrdup(path_get_basename(tmp));
 		free(tmp);
 	} else if (argc - i == 2) {
-		char *tmp = strdup(argv[i]);
+		char *tmp = mstrdup(argv[i]);
 		size_t src_len = strlen(tmp);
 		if (src_len > 1 && tmp[src_len - 1] == '/') {
 			tmp[src_len - 1] = '\0';
 		}
 		srcpath = get_absolute_path(tmp);
-		dstpath = strdup(argv[i + 1]);
+		dstpath = mstrdup(argv[i + 1]);
 		size_t dst_len = strlen(dstpath);
 		if (dst_len > 1 && dstpath[dst_len - 1] == '/') {
 			dstpath[dst_len - 1] = '\0';
@@ -917,19 +989,19 @@ static void handle_get(afc_client_t afc, int argc, char **argv)
 		const char *basen = path_get_basename(srcpath);
 		uint8_t dst_is_root = strcmp(dstpath, "/") == 0;
 		size_t len = dst_is_root ? (strlen(basen) + 2) : (strlen(dstpath) + 1 + strlen(basen) + 1);
-		char *newdst = (char *) malloc(len);
+		char *newdst = (char *) mmalloc(len);
 		if (dst_is_root) {
 			snprintf(newdst, len, "/%s", basen);
 		} else {
 			snprintf(newdst, len, "%s/%s", dstpath, basen);
 		}
-		get_file(afc, srcpath, newdst, force_overwrite, recursive_get);
+		get_file(afc, srcpath, newdst, force_overwrite, recursive_get, preserve);
 		free(srcpath);
 		free(newdst);
 		free(dstpath);
 	} else {
 		// target is not a dir or does not exist, just try to create or rewrite it
-		get_file(afc, srcpath, dstpath, force_overwrite, recursive_get);
+		get_file(afc, srcpath, dstpath, force_overwrite, recursive_get, preserve);
 		free(srcpath);
 		free(dstpath);
 	}
@@ -958,7 +1030,7 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 	struct stat fst;
 	int progress = 0;
 	size_t bufsize = 0x100000;
-	char *buf = malloc(bufsize);
+	char *buf = mmalloc(bufsize);
 
 	fstat(fileno(f), &fst);
 	if (fst.st_size >= 0x400000) {
@@ -1064,7 +1136,7 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 				if (fpath) {
 					uint8_t dst_is_root = strcmp(dstpath, "/") == 0;
 					size_t len = dst_is_root ? (strlen(ep->d_name) + 2) : (strlen(dstpath) + 1 + strlen(ep->d_name) + 1);
-					char *newdst = (char *) malloc(len);
+					char *newdst = (char *) mmalloc(len);
 					if (dst_is_root) {
 						snprintf(newdst, len, "/%s", ep->d_name);
 					} else {
@@ -1117,7 +1189,7 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 		printf("Error: Invalid number of arguments\n");
 		return;
 	}
-	char *srcpath = strdup(argv[i]);
+	char *srcpath = mstrdup(argv[i]);
 	size_t src_len = strlen(srcpath);
 	if (src_len > 1 && srcpath[src_len - 1] == '/') {
 		srcpath[src_len - 1] = '\0';
@@ -1126,7 +1198,7 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 	if (argc - i == 1) {
 		dstpath = get_absolute_path(path_get_basename(srcpath));
 	} else if (argc - i == 2) {
-		char *tmp = strdup(argv[i + 1]);
+		char *tmp = mstrdup(argv[i + 1]);
 		size_t dst_len = strlen(tmp);
 		if (dst_len > 1 && tmp[dst_len - 1] == '/') {
 			tmp[dst_len - 1] = '\0';
@@ -1156,7 +1228,7 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 			const char *basen = path_get_basename(srcpath);
 			uint8_t dst_is_root = strcmp(dstpath, "/") == 0;
 			size_t len = dst_is_root ? (strlen(basen) + 2) : (strlen(dstpath) + 1 + strlen(basen) + 1);
-			char *newdst = (char *) malloc(len);
+			char *newdst = (char *) mmalloc(len);
 			if (dst_is_root) {
 				snprintf(newdst, len, "/%s", basen);
 			} else {
@@ -1248,7 +1320,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 	while (isspace(*pos)) pos++;
 	maxlen -= (pos - cmdline);
 
-	tmpbuf = (char*)malloc(maxlen+1);
+	tmpbuf = (char*)mmalloc(maxlen+1);
 
 	while (!is_error) {
 		if (*pos == '\\') {
@@ -1300,7 +1372,7 @@ static void parse_cmdline(int* p_argc, char*** p_argv, const char* cmdline)
 				break;
 			}
 			maxlen -= tmplen;
-			tmpbuf = (char*)malloc(maxlen+1);
+			tmpbuf = (char*)mmalloc(maxlen+1);
 			tmplen = 0;
 			while (isspace(*pos)) pos++;
 		} else {
@@ -1419,7 +1491,7 @@ static void device_event_cb(const idevice_event_t* event, void* userdata)
 	}
 	if (event->event == IDEVICE_DEVICE_ADD) {
 		if (!udid) {
-			udid = strdup(event->udid);
+			udid = mstrdup(event->udid);
 		}
 		if (strcmp(udid, event->udid) == 0) {
 			connected = 1;
@@ -1464,6 +1536,10 @@ int main(int argc, char** argv)
 	signal(SIGPIPE, SIG_IGN);
 #endif
 
+	char *scratch1 = mstrdup(argv[0]);
+	myname = mstrdup(basename(scratch1));
+	free(scratch1);
+
 	while ((c = getopt_long(argc, argv, "du:nhv", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'd':
@@ -1471,11 +1547,11 @@ int main(int argc, char** argv)
 			break;
 		case 'u':
 			if (!*optarg) {
-				fprintf(stderr, "ERROR: UDID must not be empty!\n");
+				fprintf(stderr, "%s: UDID must not be empty!\n", myname);
 				print_usage(argc, argv, 1);
 				return 2;
 			}
-			udid = strdup(optarg);
+			udid = mstrdup(optarg);
 			break;
 		case 'n':
 			use_network = 1;
@@ -1492,7 +1568,7 @@ int main(int argc, char** argv)
 			return 0;
 		case OPT_DOCUMENTS:
 			if (!*optarg) {
-				fprintf(stderr, "ERROR: '--documents' requires a non-empty app ID!\n");
+				fprintf(stderr, "%s: '--documents' requires a non-empty app ID!\n", myname);
 				print_usage(argc, argv, 1);
 				return 2;
 			}
@@ -1501,7 +1577,7 @@ int main(int argc, char** argv)
 			break;
 		case OPT_CONTAINER:
 			if (!*optarg) {
-				fprintf(stderr, "ERROR: '--container' requires a not-empty app ID!\n");
+				fprintf(stderr, "%s: '--container' requires a not-empty app ID!\n", myname);
 				print_usage(argc, argv, 1);
 				return 2;
 			}
@@ -1530,7 +1606,7 @@ int main(int argc, char** argv)
 	}
 	idevice_device_list_extended_free(devices);
 	if (count == 0) {
-		fprintf(stderr, "No device found. Plug in a device or pass UDID with -u to wait for device to be available.\n");
+		fprintf(stderr, "%s: No device found. Plug in a device or pass UDID with -u to wait for device to be available.\n", myname);
 		return 1;
 	}
 
@@ -1544,23 +1620,23 @@ int main(int argc, char** argv)
 #endif
 	}
 	if (stop_requested) {
-		return 0;
+		return errors ? 1 : 0;
 	}
 
 	ret = idevice_new_with_options(&device, udid, (use_network) ? IDEVICE_LOOKUP_NETWORK : IDEVICE_LOOKUP_USBMUX);
 	if (ret != IDEVICE_E_SUCCESS) {
 		if (udid) {
-			fprintf(stderr, "ERROR: Device %s not found!\n", udid);
+			fprintf(stderr, "%s: Device %s not found!\n", myname, udid);
 		} else {
-			fprintf(stderr, "ERROR: No device found!\n");
+			fprintf(stderr, "%s: No device found!\n", myname);
 		}
 		return 1;
 	}
 
 	do {
 		if (LOCKDOWN_E_SUCCESS != (ldret = lockdownd_client_new_with_handshake(device, &lockdown, TOOL_NAME))) {
-			fprintf(stderr, "ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(ldret), ldret);
-			ret = 1;
+			fprintf(stderr, "%s: Could not connect to lockdownd: %s (%d)\n", myname, lockdownd_strerror(ldret), ldret);
+			errors++;
 			break;
 		}
 
@@ -1570,37 +1646,39 @@ int main(int argc, char** argv)
 
 		ldret = lockdownd_start_service(lockdown, service_name, &service);
 		if (ldret != LOCKDOWN_E_SUCCESS) {
-			fprintf(stderr, "ERROR: Failed to start service %s: %s (%d)\n", service_name, lockdownd_strerror(ldret), ldret);
-			ret = 1;
+			fprintf(stderr, "%s: Failed to start service %s: %s (%d)\n", myname, service_name, lockdownd_strerror(ldret), ldret);
+			errors++;
 			break;
 		}
 
 		if (appid) {
 			house_arrest_client_new(device, service, &house_arrest);
 			if (!house_arrest) {
-				fprintf(stderr, "Could not start document sharing service!\n");
-				ret = 1;
+				fprintf(stderr, "%s: Could not start document sharing service!\n", myname);
+				errors++;
 				break;
 			}
 
 			if (house_arrest_send_command(house_arrest, use_container ? "VendContainer": "VendDocuments", appid) != HOUSE_ARREST_E_SUCCESS) {
-				fprintf(stderr, "Could not send house_arrest command!\n");
-				ret = 1;
+				fprintf(stderr, "%s: Could not send house_arrest command!\n", myname);
+				errors++;
 				break;
 			}
 
 			plist_t dict = NULL;
 			if (house_arrest_get_result(house_arrest, &dict) != HOUSE_ARREST_E_SUCCESS) {
-				fprintf(stderr, "Could not get result from document sharing service!\n");
+				fprintf(stderr, "%s: Could not get result from document sharing service!\n", myname);
+				errors++;
 				break;
 			}
 			plist_t node = plist_dict_get_item(dict, "Error");
 			if (node) {
 				char *str = NULL;
 				plist_get_string_val(node, &str);
-				fprintf(stderr, "ERROR: %s\n", str);
+				fprintf(stderr, "%s: %s\n", myname, str);
+				errors++;
 				if (str && !strcmp(str, "InstallationLookupFailed")) {
-					fprintf(stderr, "The App '%s' is either not present on the device, or the 'UIFileSharingEnabled' key is not set in its Info.plist. Starting with iOS 8.3 this key is mandatory to allow access to an app's Documents folder.\n", appid);
+					fprintf(stderr, "%s: The App '%s' is either not present on the device, or the 'UIFileSharingEnabled' key is not set in its Info.plist. Starting with iOS 8.3 this key is mandatory to allow access to an app's Documents folder.\n", myname, appid);
 				}
 				free(str);
 				plist_free(dict);
@@ -1615,7 +1693,7 @@ int main(int argc, char** argv)
 		lockdownd_client_free(lockdown);
 		lockdown = NULL;
 
-		curdir = strdup("/");
+		curdir = mstrdup("/");
 		curdir_len = 1;
 
 		if (argc > 0) {
@@ -1636,5 +1714,5 @@ int main(int argc, char** argv)
 	}
 	idevice_free(device);
 
-	return ret;
+	return errors ? 1 : 0;
 }

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -62,7 +62,7 @@
 #define S_ISLNK(m)      (((m) & S_IFMT) == S_IFLNK)     /* symbolic link */
 #define S_ISSOCK(m)     (((m) & S_IFMT) == S_IFSOCK)    /* socket */
 #else
-#include <fcntl.h>
+#include <utime.h>
 #include <sys/time.h>
 #endif
 
@@ -80,14 +80,12 @@
 #include <libimobiledevice-glue/termcolors.h>
 #include <libimobiledevice-glue/utils.h>
 
-#undef st_mtime
-#undef st_birthtime
 struct afc_file_stat {
 	uint16_t st_mode;
 	uint16_t st_nlink;
 	uint64_t st_size;
-	uint64_t st_mtime;
-	uint64_t st_birthtime;
+	uint64_t st__mtime;
+	uint64_t st__birthtime;
 	uint32_t st_blocks;
 };
 
@@ -434,9 +432,9 @@ static int get_file_info_stat(afc_client_t afc, const char* path, struct afc_fil
 		}
 	}
 	stbuf->st_nlink = plist_dict_get_uint(info, "st_nlink");
-	stbuf->st_mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / NANO);
+	stbuf->st__mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / NANO);
 	/* available on iOS 7+ */
-	stbuf->st_birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / NANO);
+	stbuf->st__birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / NANO);
 	plist_free(info);
 	return 0;
 }
@@ -477,7 +475,7 @@ static void print_file_info(afc_client_t afc, const char* path, int list_verbose
 	get_file_info_stat(afc, path, &st);
 	if (list_verbose) {
 		char timebuf[64];
-		time_t t = st.st_mtime;
+		time_t t = st.st__mtime;
 		if (S_ISDIR(st.st_mode)) {
 			printf("drwxr-xr-x");
 		} else if (S_ISLNK(st.st_mode)) {
@@ -818,19 +816,18 @@ static int __mkdir(const char* path)
 static void set_mtime(const char *path, uint64_t mtime)
 {
 	int status;
-#ifdef _WIN32
 	time_t now;
 	time(&now);
+#ifdef _WIN32
 	struct _utimbuf times;
 	times.actime = now;
 	times.modtime = mtime / NANO;
-	status = _utime(dstpath, &times);
+	status = _utime(path, &times);
 #else
-	struct timespec times[2];
-	times[0].tv_nsec = UTIME_OMIT;
-	times[1].tv_sec = mtime / NANO;
-	times[1].tv_nsec = mtime % NANO;
-	status = utimensat(AT_FDCWD, path, times, 0);
+	struct utimbuf times;
+	times.actime = now;
+	times.modtime = mtime / NANO;
+	status = utime(path, &times);
 #endif
 	if (status) {
 		fprintf(stderr, "%s: Unable to set time stamp on '%s', %s\n", myname, path, strerror(errno));
@@ -1106,7 +1103,7 @@ static uint64_t get_mtime(const char *path)
 #else
 	struct stat stb;
 	status = stat(path, &stb);
-	ret = (uint64_t) stb.st_mtimespec.tv_sec * NANO + stb.st_mtimespec.tv_nsec;
+	ret = (uint64_t) stb.st_mtime * NANO;
 #endif
 	if (status) {
 		fprintf(stderr, "%s: Unable to get time stamp on '%s', %s\n", myname, path, strerror(errno));

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -97,7 +97,7 @@ static int use_network = 0;
 static idevice_subscription_context_t context = NULL;
 static char* curdir = NULL;
 static size_t curdir_len = 0;
-static char* myname = NULL;
+static const char* myname = NULL;
 static int errors = 0;
 
 static void mabort()
@@ -235,7 +235,7 @@ static void handle_help(afc_client_t afc, int argc, char** argv)
 	printf("        NOTE: This feature has been disabled in newer versions of iOS.\n");
 	printf("rm PATH - remove item at PATH\n");
 	printf("get [-rf] [-p] PATH [LOCALPATH] - transfer file at PATH from device to LOCALPATH\n");
-	printf("put [-rf] LOCALPATH [PATH] - transfer local file at LOCALPATH to device at PATH\n");
+	printf("put [-rf] [-p] LOCALPATH [PATH] - transfer local file at LOCALPATH to device at PATH\n");
 	printf("\n");
 }
 
@@ -857,6 +857,8 @@ static void set_mtime(const char *path, uint64_t mtime)
 	if (status) {
 		fprintf(stderr, "%s: Unable to set time stamp on '%s', %s\n", myname, path, strerror(errno));
 		errors++;
+	} else {
+		errno = 0;
 	}
 }
 
@@ -939,8 +941,11 @@ static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpa
 		afc_dictionary_free(entries);
 	} else {
 		succeed = get_single_file(afc, srcpath, dstpath, file_size, force_overwrite);
-		if (preserve && file_mtime) {
+		if (succeed && preserve && file_mtime) {
 			set_mtime(dstpath, file_mtime);
+			if (errno) {
+				return 0;
+			}
 		}
 	}
 	return succeed;
@@ -1112,7 +1117,29 @@ static uint8_t put_single_file(afc_client_t afc, const char *srcpath, const char
 	return succeed;
 }
 
-static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint8_t force_overwrite, uint8_t recursive_put)
+static uint64_t get_mtime(const char *path)
+{
+	int status;
+	uint64_t ret;
+#ifdef _WIN32
+	struct _stat stb;
+	status = _stat(path, &stb);
+	ret = (uint64_t) stb.st_mtime * NANO;
+#else
+	struct stat stb;
+	status = stat(path, &stb);
+	ret = (uint64_t) stb.st_mtimespec.tv_sec * NANO + stb.st_mtimespec.tv_nsec;
+#endif
+	if (status) {
+		fprintf(stderr, "%s: Unable to get time stamp on '%s', %s\n", myname, path, strerror(errno));
+		errors++;
+	} else {
+		errno = 0;
+	}
+	return ret;
+}
+
+static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint8_t force_overwrite, uint8_t recursive_put, uint8_t preserve)
 {
 	if (is_directory(srcpath)) {
 		if (!recursive_put) {
@@ -1168,7 +1195,7 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 					} else {
 						snprintf(newdst, len, "%s/%s", dstpath, ep->d_name);
 					}
-					if (!put_file(afc, fpath, newdst, force_overwrite, recursive_put)) {
+					if (!put_file(afc, fpath, newdst, force_overwrite, recursive_put, preserve)) {
 						free(newdst);
 						free(fpath);
 						return 0;
@@ -1184,7 +1211,22 @@ static uint8_t put_file(afc_client_t afc, const char *srcpath, const char *dstpa
 			return 0;
 		}
 	} else {
-		return put_single_file(afc, srcpath, dstpath, force_overwrite);
+		int ret = put_single_file(afc, srcpath, dstpath, force_overwrite);
+		if (ret && preserve)
+		{
+			uint64_t mtime = get_mtime(srcpath);
+			if (errno) {
+				return 0;
+			} else {
+				afc_error_t status = afc_set_file_time(afc, dstpath, mtime);
+				if (status != AFC_E_SUCCESS) {
+					fprintf(stderr, "%s: Unable to set time stamp on '%s', %s\n", myname, dstpath, afc_strerror(status));
+					errors++;
+					return 0;
+				}
+			}
+		}
+		return ret;
 	}
 	return 1;
 }
@@ -1197,7 +1239,7 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 		return;
 	}
 	int i = 0;
-	uint8_t force_overwrite = 0, recursive_put = 0;
+	uint8_t force_overwrite = 0, recursive_put = 0, preserve = 0;
 	for ( ; i < argc; i++) {
 		if (!strcmp(argv[i], "--")) {
 			i++;
@@ -1209,6 +1251,8 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 		} else if (!strcmp(argv[i], "-rf") || !strcmp(argv[i], "-fr")) {
 			recursive_put = 1;
 			force_overwrite = 1;
+		} else if (!strcmp(argv[i], "-p")) {
+			preserve = 1;
 		} else {
 			break;
 		}
@@ -1243,7 +1287,7 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 	afc_error_t err = afc_get_file_info_plist(afc, dstpath, &info);
 	// target does not exist, put directly
 	if (err == AFC_E_OBJECT_NOT_FOUND) {
-		put_file(afc, srcpath, dstpath, force_overwrite, recursive_put);
+		put_file(afc, srcpath, dstpath, force_overwrite, recursive_put, preserve);
 		free(srcpath);
 		free(dstpath);
 	} else {
@@ -1267,10 +1311,10 @@ static void handle_put(afc_client_t afc, int argc, char **argv)
 			free(dstpath);
 			dstpath = get_absolute_path(newdst);
 			free(newdst);
-			put_file(afc, srcpath, dstpath, force_overwrite, recursive_put);
+			put_file(afc, srcpath, dstpath, force_overwrite, recursive_put, preserve);
 		} else {
 			//target is common file, rewrite it
-			put_file(afc, srcpath, dstpath, force_overwrite, recursive_put);
+			put_file(afc, srcpath, dstpath, force_overwrite, recursive_put, preserve);
 		}
 		free(srcpath);
 		free(dstpath);
@@ -1572,9 +1616,7 @@ int main(int argc, char** argv)
 #ifdef _WIN32
 	myname = "afcclient";
 #else
-	char *scratch1 = mstrdup(argv[0]);
-	myname = mstrdup(basename(scratch1));
-	free(scratch1);
+	myname = path_get_basename(argv[0]);
 #endif
 
 	while ((c = getopt_long(argc, argv, "du:nhv", longopts, NULL)) != -1) {

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -62,7 +62,7 @@
 #define S_ISLNK(m)      (((m) & S_IFMT) == S_IFLNK)     /* symbolic link */
 #define S_ISSOCK(m)     (((m) & S_IFMT) == S_IFSOCK)    /* socket */
 #else
-#include <utime.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #endif
 
@@ -80,14 +80,23 @@
 #include <libimobiledevice-glue/termcolors.h>
 #include <libimobiledevice-glue/utils.h>
 
+#undef st_mtime
+#undef st_birthtime
 struct afc_file_stat {
 	uint16_t st_mode;
 	uint16_t st_nlink;
 	uint64_t st_size;
-	uint64_t st__mtime;
-	uint64_t st__birthtime;
+	uint64_t st_mtime;
+	uint64_t st_birthtime;
 	uint32_t st_blocks;
 };
+
+/* groan. stat is poorly standardized. there may be others guilty of this. */
+#if defined(__APPLE__) || defined(__NetBSD__)
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
+#endif
 
 static char* udid = NULL;
 static int connected = 0;
@@ -432,9 +441,9 @@ static int get_file_info_stat(afc_client_t afc, const char* path, struct afc_fil
 		}
 	}
 	stbuf->st_nlink = plist_dict_get_uint(info, "st_nlink");
-	stbuf->st__mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / NANO);
+	stbuf->st_mtime = (time_t)(plist_dict_get_uint(info, "st_mtime") / NANO);
 	/* available on iOS 7+ */
-	stbuf->st__birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / NANO);
+	stbuf->st_birthtime = (time_t)(plist_dict_get_uint(info, "st_birthtime") / NANO);
 	plist_free(info);
 	return 0;
 }
@@ -475,7 +484,7 @@ static void print_file_info(afc_client_t afc, const char* path, int list_verbose
 	get_file_info_stat(afc, path, &st);
 	if (list_verbose) {
 		char timebuf[64];
-		time_t t = st.st__mtime;
+		time_t t = st.st_mtime;
 		if (S_ISDIR(st.st_mode)) {
 			printf("drwxr-xr-x");
 		} else if (S_ISLNK(st.st_mode)) {
@@ -816,18 +825,19 @@ static int __mkdir(const char* path)
 static void set_mtime(const char *path, uint64_t mtime)
 {
 	int status;
+#ifdef _WIN32
 	time_t now;
 	time(&now);
-#ifdef _WIN32
 	struct _utimbuf times;
 	times.actime = now;
 	times.modtime = mtime / NANO;
 	status = _utime(path, &times);
 #else
-	struct utimbuf times;
-	times.actime = now;
-	times.modtime = mtime / NANO;
-	status = utime(path, &times);
+	struct timespec times[2];
+	times[0].tv_nsec = UTIME_OMIT;
+	times[1].tv_sec = mtime / NANO;
+	times[1].tv_nsec = mtime % NANO;
+	status = utimensat(AT_FDCWD, path, times, 0);
 #endif
 	if (status) {
 		fprintf(stderr, "%s: Unable to set time stamp on '%s', %s\n", myname, path, strerror(errno));
@@ -1103,7 +1113,7 @@ static uint64_t get_mtime(const char *path)
 #else
 	struct stat stb;
 	status = stat(path, &stb);
-	ret = (uint64_t) stb.st_mtime * NANO;
+	ret = (uint64_t) stb.st_mtim.tv_sec * NANO + stb.st_mtim.tv_nsec;
 #endif
 	if (status) {
 		fprintf(stderr, "%s: Unable to get time stamp on '%s', %s\n", myname, path, strerror(errno));

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -64,7 +64,6 @@
 #else
 #include <fcntl.h>
 #include <sys/time.h>
-#include <termios.h>
 #endif
 
 #ifdef HAVE_READLINE

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -839,20 +839,25 @@ static int __mkdir(const char* path)
 
 static void set_mtime(const char *path, uint64_t mtime)
 {
+	int status;
 #ifdef _WIN32
 	time_t now;
 	time(&now);
 	struct _utimbuf times;
 	times.actime = now;
 	times.modtime = mtime / NANO;
-	_utime(dstpath, &times);
+	status = _utime(dstpath, &times);
 #else
 	struct timespec times[2];
 	times[0].tv_nsec = UTIME_OMIT;
 	times[1].tv_sec = mtime / NANO;
 	times[1].tv_nsec = mtime % NANO;
-	utimensat(AT_FDCWD, path, times, 0);
+	status = utimensat(AT_FDCWD, path, times, 0);
 #endif
+	if (status) {
+		fprintf(stderr, "%s: Unable to set time stamp on '%s', %s\n", myname, path, strerror(errno));
+		errors++;
+	}
 }
 
 static uint8_t get_file(afc_client_t afc, const char *srcpath, const char *dstpath, uint8_t force_overwrite, uint8_t recursive_get, uint8_t preserve)

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -194,7 +194,7 @@ static void get_input(char *buf, int maxlen)
 		}
 	}
 	buf[len] = 0;
-	if (!len && c == EOF) {
+	if (c == EOF) {
 		/* exit on EOF */
 		stop_requested++;
 	}

--- a/tools/afcclient.c
+++ b/tools/afcclient.c
@@ -48,6 +48,7 @@
 #include <sys/types.h>
 #include <sys/utime.h>
 #include <conio.h>
+#include <io.h>
 #define sleep(x) Sleep(x*1000)
 #define S_IFMT          0170000         /* [XSI] type of file mask */
 #define S_IFIFO         0010000         /* [XSI] named pipe (fifo) */
@@ -99,6 +100,7 @@ static char* curdir = NULL;
 static size_t curdir_len = 0;
 static const char* myname = NULL;
 static int errors = 0;
+static uint8_t interactive = 0;
 
 static void mabort()
 {
@@ -170,47 +172,30 @@ static void print_usage(int argc, char **argv, int is_error)
 	);
 }
 
-#ifndef HAVE_READLINE
-#ifdef _WIN32
-#define BS_CC '\b'
-#define getch _getch
-#else
-#define BS_CC 0x7f
-#define getch getchar
-#endif
+int stop_requested = 0;
+
 static void get_input(char *buf, int maxlen)
 {
 	int len = 0;
 	int c;
 
-	while ((c = getch())) {
+	while ((c = getchar()) != EOF) {
 		if ((c == '\r') || (c == '\n')) {
 			break;
 		}
-		if (isprint(c)) {
-			if (len < maxlen-1) {
-				buf[len++] = c;
-#ifdef _WIN32
-				fputc(c, stdout);
-#endif
-			}
-		} else if (c == BS_CC) {
-			if (len > 0) {
-				fputs("\b \b", stdout);
-				len--;
-			} else {
-				fputc(0x07, stdout);
-			}
+		if (len < maxlen - 1) {
+			buf[len++] = c;
 		}
 	}
 	buf[len] = 0;
+	if (!len && c == EOF) {
+		/* exit on EOF */
+		stop_requested++;
+	}
 }
-#endif
 
 #define OPT_DOCUMENTS 1
 #define OPT_CONTAINER 2
-
-int stop_requested = 0;
 
 static void handle_signal(int sig)
 {
@@ -681,25 +666,19 @@ static void handle_link(afc_client_t afc, int argc, char** argv)
 
 static int ask_yesno(const char* prompt)
 {
-	int ret = 0;
 #ifdef HAVE_READLINE
-	char* result = readline(prompt);
-	if (result && result[0] == 'y') {
-		ret = 1;
+	if (interactive) {
+		char* result = readline(prompt);
+		int ret = result && result[0] == 'y';
+		free(result);
+		return ret;
 	}
-#else
+#endif
 	char cmdbuf[2] = {0, };
 	printf("%s", prompt);
 	fflush(stdout);
 	get_input(cmdbuf, sizeof(cmdbuf));
-	if (cmdbuf[0] == 'y') {
-		ret = 1;
-	}
-#endif
-#ifdef HAVE_READLINE
-	free(result);
-#endif
-	return ret;
+	return cmdbuf[0] == 'y';
 }
 
 static void handle_remove(afc_client_t afc, int argc, char** argv)
@@ -1518,6 +1497,21 @@ static int process_args(afc_client_t afc, int argc, char** argv)
 	return 0;
 }
 
+char *_get_input(const char *prompt)
+{
+#ifdef HAVE_READLINE
+	if (interactive) {
+		return readline(prompt);
+	}
+#endif
+	const size_t bufsize = 4096;
+	char *buf = mmalloc(bufsize);
+	printf("%s", prompt);
+	fflush(stdout);
+	get_input(buf, bufsize);
+	return buf;
+}
+
 static void start_cmdline(afc_client_t afc)
 {
 	while (!stop_requested) {
@@ -1532,24 +1526,19 @@ static void start_cmdline(afc_client_t afc)
 			plen = plim;
 		}
 		snprintf(prompt, 128, FG_BLACK BG_LIGHT_GRAY "afc:" COLOR_RESET FG_BRIGHT_YELLOW BG_BLUE "%.*s" COLOR_RESET " > ", plen, ppath);
-#ifdef HAVE_READLINE
-		char* cmd = readline(prompt);
+		char *cmd = _get_input(prompt);
 		if (!cmd || !*cmd) {
 			free(cmd);
 			continue;
 		}
-		add_history(cmd);
-		parse_cmdline(&argc, &argv, cmd);
-#else
-		char cmdbuf[4096];
-		printf("%s", prompt);
-		fflush(stdout);
-		get_input(cmdbuf, sizeof(cmdbuf));
-		parse_cmdline(&argc, &argv, cmdbuf);
-#endif
 #ifdef HAVE_READLINE
-		free(cmd);
+		if (interactive) {
+			add_history(cmd);
+		}
 #endif
+		parse_cmdline(&argc, &argv, cmd);
+		free(cmd);
+
 		/* process arguments */
 		if (argv && argv[0]) {
 			if (process_args(afc, argc, argv) < 0) {
@@ -1615,8 +1604,10 @@ int main(int argc, char** argv)
 
 #ifdef _WIN32
 	myname = "afcclient";
+	interactive = _isatty(0) && _isatty(1) && _isatty(2);
 #else
 	myname = path_get_basename(argv[0]);
+	interactive = isatty(0) && isatty(1) && isatty(2);
 #endif
 
 	while ((c = getopt_long(argc, argv, "du:nhv", longopts, NULL)) != -1) {


### PR DESCRIPTION
I have made a batch of changes to afcclient and was wondering if you might be interested in incorporating any of them.

My main focus was to make afcclient more useful for scripting:
• Add -p (preserve mtime) option to get and put subcommands.
• All errors go to stderr, identified with program name, per POSIX convention.
• Always exit with a nonzero status on error.
• Detect I/O redirection and disable readline if so, to facilitate scripting.
• Detect EOF on standard input and exit, again to facilitate scripting.
• Explicitly detect and report all out of memory conditions.

Notes:
• I don’t have access to a Windows system, so I was unable to do any testing on Windows.
• My Linux (Ubuntu 24 LTS)  access is limited to a virtual host in the cloud, so while I was able to confirm it will build, I am not able to connect my iPhone and verify that it runs properly on Linux.
• There seems to be a bug in the configuration system that stops readline  from being properly detected and linked in; I did not attempt to address it (my feeling is there's enough changes here already).
