### PR TITLE
ostrace.c callback function check

### DIFF
--- a/src/ostrace.c
+++ b/src/ostrace.c
@@ -250,7 +250,8 @@ void *ostrace_worker(void *arg)
 			debug_info("Failed to receive all data, got %d/%d", received, rlen);
 			break;
 		}
-		oswt->cbfunc(buf, received, oswt->user_data);
+		if(oswt->cbfunc)
+			oswt->cbfunc(buf, received, oswt->user_data);
 		free(buf);
 	}
 


### PR DESCRIPTION
altough it doesn't make sense to not add callback when using this functionality, since it's pointer to function, it still might be null (either intentionally, or unintentionally), and that will crash program.