### PR TITLE
Add home screen icon metrics to sbservices

### DIFF
--- a/cython/sbservices.pxi
+++ b/cython/sbservices.pxi
@@ -13,6 +13,7 @@ cdef extern from "libimobiledevice/sbservices.h":
     sbservices_error_t sbservices_get_icon_state(sbservices_client_t client, plist.plist_t *state, char *format_version)
     sbservices_error_t sbservices_set_icon_state(sbservices_client_t client, plist.plist_t newstate)
     sbservices_error_t sbservices_get_icon_pngdata(sbservices_client_t client, char *bundleId, char **pngdata, uint64_t *pngsize)
+    sbservices_error_t sbservices_get_home_screen_icon_metrics(sbservices_client_t client, plist.plist_t *metrics)
 
 cdef class SpringboardServicesError(BaseError):
     def __init__(self, *args, **kwargs):
@@ -78,3 +79,18 @@ cdef class SpringboardServicesClient(PropertyListService):
         except BaseError, e:
             free(pngdata)
             raise
+
+    property home_screen_icon_metrics:
+        def __get__(self):
+            cdef:
+                plist.plist_t c_node = NULL
+                sbservices_error_t err
+            err = sbservices_get_home_screen_icon_metrics(self._c_client, &c_node)
+            try:
+                self.handle_error(err)
+
+                return plist.plist_t_to_node(c_node)
+            except BaseError, e:
+                if c_node != NULL:
+                    plist.plist_free(c_node)
+                raise

--- a/include/libimobiledevice/sbservices.h
+++ b/include/libimobiledevice/sbservices.h
@@ -168,6 +168,19 @@ LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_interface_orientation(sbs
  */
 LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_home_screen_wallpaper_pngdata(sbservices_client_t client, char **pngdata, uint64_t *pngsize);
 
+/**
+ * Get home screen icon metrics.
+ *
+ * @param client The connected sbservices client to use.
+ * @param metrics Pointer that will point to a newly allocated plist containing
+ *     the home screen icon metrics. It is up to the caller to free the memory.
+ *
+ * @return SBSERVICES_E_SUCCESS on success, SBSERVICES_E_INVALID_ARG when
+ *     client or metrics are invalid, or an SBSERVICES_E_* error code
+ *     otherwise.
+ */
+LIBIMOBILEDEVICE_API sbservices_error_t sbservices_get_home_screen_icon_metrics(sbservices_client_t client, plist_t *metrics);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sbservices.c
+++ b/src/sbservices.c
@@ -298,3 +298,40 @@ leave_unlock:
 	sbservices_unlock(client);
 	return res;
 }
+
+sbservices_error_t sbservices_get_home_screen_icon_metrics(sbservices_client_t client, plist_t *metrics)
+{
+	if (!client || !client->parent || !metrics)
+		return SBSERVICES_E_INVALID_ARG;
+
+	sbservices_error_t res = SBSERVICES_E_UNKNOWN_ERROR;
+
+	plist_t dict = plist_new_dict();
+	plist_dict_set_item(dict, "command", plist_new_string("getHomeScreenIconMetrics"));
+
+	sbservices_lock(client);
+
+	res = sbservices_error(property_list_service_send_binary_plist(client->parent, dict));
+	if (res != SBSERVICES_E_SUCCESS) {
+		debug_info("could not send plist, error %d", res);
+		goto leave_unlock;
+	}
+	plist_free(dict);
+	dict = NULL;
+
+	res = sbservices_error(property_list_service_receive_plist(client->parent, metrics));
+	if (res != SBSERVICES_E_SUCCESS) {
+		debug_info("could not get home screen icon metrics, error %d", res);
+		if (*metrics) {
+			plist_free(*metrics);
+			*metrics = NULL;
+		}
+	}
+
+leave_unlock:
+	if (dict) {
+		plist_free(dict);
+	}
+	sbservices_unlock(client);
+	return res;
+}


### PR DESCRIPTION
This adds support for the "getHomeScreenIconMetrics" SpringBoardServices command. There are also "getWallpaperInfo" and "getWallpaperPreviewImage" commands that could be added from `/usr/libexec/springboardservicesrelay`.
