### PR TITLE
Fix libimobiledevice_version void prototype warning

### DIFF
--- a/include/libimobiledevice/libimobiledevice.h
+++ b/include/libimobiledevice/libimobiledevice.h
@@ -430,7 +430,7 @@ LIBIMOBILEDEVICE_API const char* idevice_strerror(idevice_error_t err);
  *
  * @return The libimobiledevice version as static ascii string
  */
-LIBIMOBILEDEVICE_API const char* libimobiledevice_version();
+LIBIMOBILEDEVICE_API const char* libimobiledevice_version(void);
 
 /* macros */
 /** Helper macro to get a numerical representation of a product version tuple */

--- a/src/idevice.c
+++ b/src/idevice.c
@@ -209,7 +209,7 @@ INITIALIZER(internal_idevice_init)
 	atexit(internal_idevice_deinit);
 }
 
-const char* libimobiledevice_version()
+const char* libimobiledevice_version(void)
 {
 #ifndef PACKAGE_VERSION
 #error PACKAGE_VERSION is not defined!


### PR DESCRIPTION
This fixes:

```
warning: a function declaration without a prototype is deprecated in all
      versions of C [-Wstrict-prototypes]
    1 | const char* libimobiledevice_version();
      |                                     ^
      |                                      void
1 warning generated.
```

Before:
```
const char* libimobiledevice_version();

int main(void)
{
	return libimobiledevice_version() != 0;
}
```

After:
```
const char* libimobiledevice_version(void);

int main(void)
{
	return libimobiledevice_version() != 0;
}
```