### PR TITLE
docs: drop obsolete libtatsu source-build note

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ sudo apt-get install \
 	libssl-dev \
 	usbmuxd
 ```
-NOTE: [libtatsu](https://github.com/libimobiledevice/libtatsu) (and thus `libtatsu-dev`)
-is a new library that was just published recently, you have to
-[build it from source](https://github.com/libimobiledevice/libtatsu?tab=readme-ov-file#building).
 
 If you want to optionally build the documentation or Python bindings use:
 ```shell


### PR DESCRIPTION
The Debian/Ubuntu installation section still says `libtatsu-dev` must be built from source because the library was newly published. That note is now obsolete because the package is available through current Debian/Ubuntu repositories.

This removes only the stale source-build note while keeping `libtatsu-dev` in the dependency list.