### PR TITLE
build: discover python3 before Python development check

### DIFF
--- a/m4/cython_python.m4
+++ b/m4/cython_python.m4
@@ -1,6 +1,6 @@
 AC_DEFUN([CYTHON_PYTHON],[
         AC_REQUIRE([AC_PROG_CYTHON])
-        AC_REQUIRE([AX_PYTHON_DEVEL])
+        AX_PYTHON_DEVEL
         test "x$1" != "xno" || cython_shadow=" -noproxy"
         AC_SUBST([CYTHON_PYTHON_OPT],[-python$cython_shadow])
         AC_SUBST([CYTHON_PYTHON_CPPFLAGS],[$PYTHON_CPPFLAGS])


### PR DESCRIPTION
`CYTHON_PYTHON` currently uses `AC_REQUIRE([AX_PYTHON_DEVEL])`. Autoconf therefore emits the development check before the surrounding `AM_PATH_PYTHON([3.0], ...)` call, so systems that provide `python3` but no `python` fail before Automake gets a chance to discover `python3`.

Invoke `AX_PYTHON_DEVEL` in place instead. This lets `AM_PATH_PYTHON` select a Python 3 interpreter first; `AX_PYTHON_DEVEL` then reuses that `PYTHON` value for the development checks.

Validation:
- regenerated `configure` with `NOCONFIGURE=1 ./autogen.sh`
- confirmed the Automake `python python3 ...` search now precedes the AX_PYTHON_DEVEL version/development checks
- ran `configure` with `PATH=/usr/bin:/bin` on a host where `python3` is available; verified the old `Cannot find python...` failure is absent
- `git diff --check`

Fixes #1706.
