### PR TITLE
ci: use sysconfig instead of distutils on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,8 @@ jobs:
           PYTHON3_BIN=`xcrun -f python3`
           if test -x $PYTHON3_BIN; then
             export PYTHON=$PYTHON3_BIN
-            PYTHON_VER=`$PYTHON3_BIN -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('VERSION'))"`
-            PYTHON_EXEC_PREFIX=`$PYTHON3_BIN -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('exec_prefix'))"`
+            PYTHON_VER=`$PYTHON3_BIN -c "import sysconfig; print(sysconfig.get_config_var('VERSION'))"`
+            PYTHON_EXEC_PREFIX=`$PYTHON3_BIN -c "import sysconfig; print(sysconfig.get_config_var('exec_prefix'))"`
             PYTHON_LIBS_PATH=$PYTHON_EXEC_PREFIX/lib
             PYTHON_FRAMEWORK_PATH=$PYTHON_EXEC_PREFIX/Python3
             export PYTHON_CPPFLAGS="-I$PYTHON_EXEC_PREFIX/Headers"


### PR DESCRIPTION
The macOS build workflow still imports `distutils.sysconfig` to read Python's `VERSION` and `exec_prefix`. `distutils` was removed from the Python standard library in Python 3.12, while these values are available directly from `sysconfig`.

Replace the two explicit `distutils.sysconfig` imports with standard-library `sysconfig`. The bundled `AX_PYTHON_DEVEL` macro is already current with Autoconf Archive serial 37 and prefers `sysconfig`, so no vendored macro change is needed here.

Validation:
- confirmed `sysconfig.get_config_var('VERSION')` and `sysconfig.get_config_var('exec_prefix')` return values
- no remaining `distutils` references in `.github/workflows`
- `git diff --check`

Addresses the remaining workflow item in #1618.
